### PR TITLE
Add caffe support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 sudo: required
+services:
+    - docker
 dist: trusty
 language: python
 python:
@@ -59,13 +61,15 @@ before_install:
     - python -c 'import torch; import tensorflow; print(tensorflow.__version__); print(torch.__version__)'
 
     - pip install pytest-faulthandler
+    - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then docker pull bvlc/caffe:cpu; fi
 install:
     - pip install -e .
 script:
     - pytest --collect-only
       # tf eager cannot be run in the same process as standard tf
-    - pytest --ignore=foolbox/tests/test_models_tensorflow_eager.py
+    - pytest --ignore=foolbox/tests/test_models_tensorflow_eager.py --ignore=foolbox/tests/test_models_caffe.py
     - pytest --cov-append foolbox/tests/test_models_tensorflow_eager.py
+    - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then docker run -v `pwd`:`pwd` bvlc/caffe:cpu  sh -c "cd `pwd` && bash foolbox/tests/run_caffe_test.sh"; fi
     - flake8 --ignore E402,E741,W503,W504 .
 after_success:
     - coveralls

--- a/foolbox/models/__init__.py
+++ b/foolbox/models/__init__.py
@@ -21,3 +21,4 @@ from .theano import TheanoModel  # noqa: F401
 from .lasagne import LasagneModel  # noqa: F401
 from .mxnet import MXNetModel  # noqa: F401
 from .mxnet_gluon import MXNetGluonModel  # noqa: F401
+from .caffe import CaffeModel  # noqa: F401

--- a/foolbox/models/caffe.py
+++ b/foolbox/models/caffe.py
@@ -1,0 +1,72 @@
+from __future__ import absolute_import
+
+from .base import DifferentiableModel
+from .. import utils
+
+
+class CaffeModel(DifferentiableModel):
+    def __init__(self,
+                 net,
+                 bounds,
+                 channel_axis=1,
+                 preprocessing=(0, 1),
+                 data_blob_name="data",
+                 label_blob_name="label",
+                 output_blob_name="output"):
+        super(CaffeModel, self).__init__(bounds=bounds,
+                                         channel_axis=channel_axis,
+                                         preprocessing=preprocessing)
+        import caffe
+        self.net = net
+        assert isinstance(net, caffe.Net)
+        assert data_blob_name in self.net.blobs
+        assert label_blob_name in self.net.blobs
+        self.data_blob_name = data_blob_name
+        self.label_blob_name = label_blob_name
+        self.output_blob_name = output_blob_name
+
+    def num_classes(self):
+        return self.net.blobs[self.output_blob_name].data.shape[-1]
+
+    def batch_predictions(self, images):
+        images, _ = self._process_input(images)
+        self.net.blobs[self.data_blob_name].reshape(*images.shape)
+        self.net.blobs[self.label_blob_name].reshape(images.shape[0])
+        self.net.blobs[self.data_blob_name].data[:] = images
+        self.net.forward()
+        return self.net.blobs[self.output_blob_name].data
+
+    def predictions_and_gradient(self, image, label):
+        input_shape = image.shape
+
+        image, dpdx = self._process_input(image)
+        self.net.blobs[self.data_blob_name].data[0, :] = image
+        self.net.blobs[self.label_blob_name].data[0] = label
+
+        self.net.forward()
+        predictions = self.net.blobs[self.output_blob_name].data[0]
+
+        grad_data = self.net.backward(diffs=[self.data_blob_name])
+        grad = grad_data[self.data_blob_name][0]
+        grad = self._process_gradient(dpdx, grad)
+        assert grad.shape == input_shape
+
+        return predictions, grad
+
+    def _loss_fn(self, image, label):
+        logits = self.batch_predictions(image[None])
+        return utils.batch_crossentropy([label], logits)
+
+    def backward(self, gradient, image):
+        input_shape = image.shape
+        image, dpdx = self._process_input(image)
+        self.net.blobs[self.data_blob_name].data[:] = image
+        self.net.forward()
+        self.net.blobs[self.output_blob_name].diff[...] = gradient
+        grad_data = self.net.backward(start=self.output_blob_name,
+                                      diffs=[self.data_blob_name])
+        grad = grad_data[self.data_blob_name][0]
+        grad = self._process_gradient(dpdx, grad)
+        assert grad.shape == input_shape
+
+        return grad

--- a/foolbox/tests/run_caffe_test.sh
+++ b/foolbox/tests/run_caffe_test.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Only python2 caffe image is provided now.
+# See https://github.com/BVLC/caffe/issues/5781
+
+pip install -r requirements-dev.txt
+pip install mock
+pip install -e .
+mkdir /mock
+cat >>/mock/tensorflow.py<<EOF
+__version__ = "mock"
+EOF
+cat >>/mock/torch.py<<EOF
+__version__ = "mock"
+EOF
+
+# clear cache for importing mock modules without conflicts
+find . -type d -name __pycache__  -o \( -type f -name '*.py[co]' \) -print | xargs rm -rf
+
+PYTHONPATH="/mock:${PYTHONPATH}" pytest --cov-append foolbox/tests/test_models_caffe.py

--- a/foolbox/tests/test_models_caffe.py
+++ b/foolbox/tests/test_models_caffe.py
@@ -1,0 +1,167 @@
+import pytest
+import numpy as np
+
+from foolbox.models import CaffeModel
+
+
+@pytest.mark.parametrize("bn_model_caffe, num_classes",
+                         [(10, 10), (1000, 1000)],
+                         indirect=["bn_model_caffe"])
+def test_caffe_model(bn_model_caffe, num_classes):
+    model = bn_model_caffe
+    test_images = np.random.rand(2, num_classes, 5, 5).astype(np.float32)
+    test_label = 7
+
+    assert model.batch_predictions(test_images).shape \
+        == (2, num_classes)
+
+    test_logits = model.predictions(test_images[0])
+    assert test_logits.shape == (num_classes,)
+
+    test_gradient = model.gradient(test_images[0], test_label)
+    assert test_gradient.shape == test_images[0].shape
+
+    np.testing.assert_almost_equal(
+        model.predictions_and_gradient(test_images[0], test_label)[0],
+        test_logits)
+    np.testing.assert_almost_equal(
+        model.predictions_and_gradient(test_images[0], test_label)[1],
+        test_gradient)
+
+    assert model.num_classes() == num_classes
+
+
+def test_caffe_model_gradient(tmpdir):
+    import caffe
+    from caffe import layers as L
+
+    bounds = (0, 255)
+    channels = num_classes = 1000
+
+    net_spec = caffe.NetSpec()
+    net_spec.data = L.Input(name="data",
+                            shape=dict(dim=[1, num_classes, 5, 5]))
+    net_spec.reduce_1 = L.Reduction(net_spec.data,
+                                    reduction_param={"operation": 4,
+                                                     "axis": 3})
+    net_spec.output = L.Reduction(net_spec.reduce_1,
+                                  reduction_param={"operation": 4,
+                                                   "axis": 2})
+    net_spec.label = L.Input(name="label",
+                             shape=dict(dim=[1]))
+    net_spec.loss = L.SoftmaxWithLoss(net_spec.output, net_spec.label)
+    wf = tmpdir.mkdir("test_models_caffe")\
+               .join("test_caffe_model_gradient_proto_{}.prototxt"
+                     .format(num_classes))
+    wf.write("force_backward: true\n" + str(net_spec.to_proto()))
+    preprocessing = (np.arange(num_classes)[:, None, None],
+                     np.random.uniform(size=(channels, 5, 5)) + 1)
+    net = caffe.Net(str(wf), caffe.TEST)
+    model = CaffeModel(
+        net,
+        bounds=bounds,
+        preprocessing=preprocessing)
+
+    epsilon = 1e-2
+
+    np.random.seed(23)
+    test_image = np.random.rand(channels, 5, 5).astype(np.float32)
+    test_label = 7
+
+    _, g1 = model.predictions_and_gradient(test_image, test_label)
+
+    l1 = model._loss_fn(test_image - epsilon / 2 * g1, test_label)
+    l2 = model._loss_fn(test_image + epsilon / 2 * g1, test_label)
+    assert 1e4 * (l2 - l1) > 1
+
+    # make sure that gradient is numerically correct
+    np.testing.assert_array_almost_equal(
+        1e4 * (l2 - l1),
+        1e4 * epsilon * np.linalg.norm(g1)**2,
+        decimal=1)
+
+
+@pytest.mark.parametrize("bn_model_caffe, num_classes",
+                         [(10, 10), (1000, 1000)],
+                         indirect=["bn_model_caffe"])
+def test_caffe_backward(bn_model_caffe, num_classes):
+    model = bn_model_caffe
+    test_image = np.random.rand(num_classes, 5, 5).astype(np.float32)
+    test_grad_pre = np.random.rand(num_classes).astype(np.float32)
+
+    test_grad = model.backward(test_grad_pre, test_image)
+    assert test_grad.shape == test_image.shape
+
+    manual_grad = np.repeat(np.repeat(
+        (test_grad_pre / 25.).reshape((-1, 1, 1)),
+        5, axis=1), 5, axis=2)
+
+    np.testing.assert_almost_equal(
+        test_grad,
+        manual_grad)
+
+
+def test_caffe_model_preprocessing_shape_change(tmpdir):
+    import caffe
+    from caffe import layers as L
+
+    bounds = (0, 255)
+    channels = num_classes = 1000
+
+    net_spec = caffe.NetSpec()
+    net_spec.data = L.Input(name="data",
+                            shape=dict(dim=[1, num_classes, 5, 5]))
+    net_spec.reduce_1 = L.Reduction(net_spec.data,
+                                    reduction_param={"operation": 4,
+                                                     "axis": 3})
+    net_spec.output = L.Reduction(net_spec.reduce_1,
+                                  reduction_param={"operation": 4, "axis": 2})
+    net_spec.label = L.Input(name="label", shape=dict(dim=[1]))
+    net_spec.loss = L.SoftmaxWithLoss(net_spec.output, net_spec.label)
+    wf = tmpdir.mkdir("test_models_caffe")\
+               .join("test_caffe_model_preprocessing_shape_change_{}.prototxt"
+                     .format(num_classes))
+    wf.write("force_backward: true\n" + str(net_spec.to_proto()))
+    net = caffe.Net(str(wf), caffe.TEST)
+    model1 = CaffeModel(
+        net,
+        bounds=bounds)
+
+    def preprocessing2(x):
+        if x.ndim == 3:
+            x = np.transpose(x, axes=(2, 0, 1))
+        elif x.ndim == 4:
+            x = np.transpose(x, axes=(0, 3, 1, 2))
+
+        def grad(dmdp):
+            assert dmdp.ndim == 3
+            dmdx = np.transpose(dmdp, axes=(1, 2, 0))
+            return dmdx
+
+        return x, grad
+
+    model2 = CaffeModel(
+        net,
+        bounds=bounds,
+        preprocessing=preprocessing2)
+
+    np.random.seed(22)
+    test_images_nhwc = np.random.rand(2, 5, 5, channels).astype(np.float32)
+    test_images_nchw = np.transpose(test_images_nhwc, (0, 3, 1, 2))
+
+    p1 = model1.batch_predictions(test_images_nchw)
+    p2 = model2.batch_predictions(test_images_nhwc)
+
+    assert np.all(p1 == p2)
+
+    p1 = model1.predictions(test_images_nchw[0])
+    p2 = model2.predictions(test_images_nhwc[0])
+
+    assert np.all(p1 == p2)
+
+    g1 = model1.gradient(test_images_nchw[0], 3)
+    assert g1.ndim == 3
+    g1 = np.transpose(g1, (1, 2, 0))
+    g2 = model2.gradient(test_images_nhwc[0], 3)
+
+    np.testing.assert_array_almost_equal(g1, g2)


### PR DESCRIPTION
Thank you for your excellent work in providing foolbox. We are using it in our projects now. 

I am not an expert in Caffe, however, as we will benchmark many algorithms implemented in caffe in our project, I try to implement a caffe wrapper for foolbox. However there are some issues that I do not know how to handle more elegantly. I will appreciate it if you can help me with this pull request.

## TEST
The setup of caffe env is somehow more troublesome than other frameworks. It's not a simple 'pip install', so for now, in the automatic travis CI test, i only use the offical caffe docker(cpu) for test(python 2.7): https://github.com/BVLC/caffe/tree/master/docker. There is no python3.6 caffe docker provided by the offical repo, so I do not include it in the automatic test.

Also, I test it locally, i cloned the lasted caffe repo:  https://github.com/BVLC/caffe/tree/99bd99795dcdf0b1d3086a8d67ab1782a8a08383, compiled it and compiled pycaffe using python3.6. I tried several attacks using foolbox(boundary, L2 iterative gradient attack, C&W), and it works well in both gpu/cpu mode. Here is my code of incorporating caffe to our AVC competition test code: https://github.com/walkerning/adversarial_dmodels/blob/master/dmodels/caffe/model.py

## ISSUES
However, there are some issues on which i might need help, because the solution now is not so elegant.
1. When constructing a caffe Net using `TEST` mode, caffe will not compute the gradient, so you must add a line in the prototxt:
```
force_backward: true
```
[This](https://github.com/walkerning/adversarial_dmodels/blob/master/dmodels/caffe/model.py#L34) is an example of how I programmatically handle this in our AVC wrapper code of foolbox.
2. When attacking using the gradient information, you must supply a prototxt with the loss layer defined in it. This is not so flexible in my opinion. I don't know what is the best way to add auto-grad loss functions (should we write loss function and its gradient function for caffe alone?)
3. The test cases should cover attacks on CaffeModel. I can work on this.
