### PR TITLE
Enabled module selection

### DIFF
--- a/foolbox/zoo/model_loader.py
+++ b/foolbox/zoo/model_loader.py
@@ -12,12 +12,13 @@ else:  # pragma: no cover
 class ModelLoader(ABC):
 
     @abstractmethod
-    def load(self, path, **kwargs):
+    def load(self, path, module_name='foolbox_model', **kwargs):
         """
         Load a model from a local path, to which a git repository
         has been previously cloned to.
 
         :param path: the path to the local repository containing the code
+        :param module_name: the name of the module to import
         :param kwargs: parameters for the to be loaded model
         :return: a foolbox-wrapped model
         """
@@ -40,7 +41,7 @@ class ModelLoader(ABC):
 
 class DefaultLoader(ModelLoader):
 
-    def load(self, path, **kwargs):
-        module = ModelLoader._import_module(path)
+    def load(self, path, module_name='foolbox_model', **kwargs):
+        module = ModelLoader._import_module(path, module_name=module_name)
         model = module.create(**kwargs)
         return model

--- a/foolbox/zoo/model_loader.py
+++ b/foolbox/zoo/model_loader.py
@@ -42,8 +42,5 @@ class DefaultLoader(ModelLoader):
 
     def load(self, path, **kwargs):
         module = ModelLoader._import_module(path)
-        if kwargs:  # Empty dictionaries evaluate fo false
-            model = module.create(**kwargs)
-        else:  # For backwards compatibility
-            model = module.create()
+        model = module.create(**kwargs)
         return model

--- a/foolbox/zoo/model_loader.py
+++ b/foolbox/zoo/model_loader.py
@@ -39,7 +39,7 @@ class ModelLoader(ABC):
 
 class DefaultLoader(ModelLoader):
 
-    def load(self, path, module_name='foolbox_model'):
-        module = ModelLoader._import_module(path, module_name)
-        model = module.create()
+    def load(self, path, **kwargs):
+        module = ModelLoader._import_module(path)
+        model = module.create(kwargs)
         return model

--- a/foolbox/zoo/model_loader.py
+++ b/foolbox/zoo/model_loader.py
@@ -12,12 +12,13 @@ else:  # pragma: no cover
 class ModelLoader(ABC):
 
     @abstractmethod
-    def load(self, path):
+    def load(self, path, **kwargs):
         """
         Load a model from a local path, to which a git repository
         has been previously cloned to.
 
         :param path: the path to the local repository containing the code
+        :param kwargs: parameters for the to be loaded model
         :return: a foolbox-wrapped model
         """
         pass  # pragma: no cover
@@ -41,5 +42,8 @@ class DefaultLoader(ModelLoader):
 
     def load(self, path, **kwargs):
         module = ModelLoader._import_module(path)
-        model = module.create(kwargs)
+        if kwargs:  # Empty dictionaries evaluate fo false
+            model = module.create(**kwargs)
+        else:  # For backwards compatibility
+            model = module.create()
         return model

--- a/foolbox/zoo/zoo.py
+++ b/foolbox/zoo/zoo.py
@@ -2,7 +2,7 @@ from .git_cloner import clone
 from .model_loader import ModelLoader
 
 
-def get_model(url, **kwargs):
+def get_model(url, module_name='foolbox_model', **kwargs):
     """
 
     Provides utilities to download foolbox-compatible robust models
@@ -35,12 +35,12 @@ def get_model(url, **kwargs):
         - https://github.com/bethgelab/defensive-distillation.git
 
     :param url: URL to the git repository
+    :param module_name: the name of the module to import
     :param kwargs: Optional set of parameters that will be used by the
         to be instantiated model.
     :return: a foolbox-wrapped model instance
     """
     repo_path = clone(url)
     loader = ModelLoader.get()
-    model = loader.load(repo_path, **kwargs)
-
+    model = loader.load(repo_path, module_name=module_name, **kwargs)
     return model

--- a/foolbox/zoo/zoo.py
+++ b/foolbox/zoo/zoo.py
@@ -2,7 +2,7 @@ from .git_cloner import clone
 from .model_loader import ModelLoader
 
 
-def get_model(url):
+def get_model(url, module_name='foolbox_model'):
     """
 
     Provides utilities to download foolbox-compatible robust models
@@ -21,6 +21,10 @@ def get_model(url):
     I.e. models need to have a `foolbox_model.py` file
     with a `create()`-function, which returns a foolbox-wrapped model.
 
+    Using the module_name parameter it can be specified which module
+    should be loaded. This is useful when multiple models are stored
+    in the same repository.
+
     Example repositories:
 
         - https://github.com/bethgelab/AnalysisBySynthesis
@@ -31,10 +35,11 @@ def get_model(url):
         - https://github.com/bethgelab/defensive-distillation.git
 
     :param url: URL to the git repository
+    :param module_name: Name of the module to be loaded
     :return: a foolbox-wrapped model instance
     """
     repo_path = clone(url)
     loader = ModelLoader.get()
-    model = loader.load(repo_path)
+    model = loader.load(repo_path, module_name)
 
     return model

--- a/foolbox/zoo/zoo.py
+++ b/foolbox/zoo/zoo.py
@@ -41,6 +41,6 @@ def get_model(url, **kwargs):
     """
     repo_path = clone(url)
     loader = ModelLoader.get()
-    model = loader.load(repo_path, kwargs)
+    model = loader.load(repo_path, **kwargs)
 
     return model

--- a/foolbox/zoo/zoo.py
+++ b/foolbox/zoo/zoo.py
@@ -2,7 +2,7 @@ from .git_cloner import clone
 from .model_loader import ModelLoader
 
 
-def get_model(url, module_name='foolbox_model'):
+def get_model(url, **kwargs):
     """
 
     Provides utilities to download foolbox-compatible robust models
@@ -21,9 +21,9 @@ def get_model(url, module_name='foolbox_model'):
     I.e. models need to have a `foolbox_model.py` file
     with a `create()`-function, which returns a foolbox-wrapped model.
 
-    Using the module_name parameter it can be specified which module
-    should be loaded. This is useful when multiple models are stored
-    in the same repository.
+    Using the kwargs parameter it is possible to input an arbitrary number
+    of parameters to this methods call. These parameters are forwarded to
+    the instantiated model.
 
     Example repositories:
 
@@ -35,11 +35,12 @@ def get_model(url, module_name='foolbox_model'):
         - https://github.com/bethgelab/defensive-distillation.git
 
     :param url: URL to the git repository
-    :param module_name: Name of the module to be loaded
+    :param kwargs: Optional set of parameters that will be used by the
+        to be instantiated model.
     :return: a foolbox-wrapped model instance
     """
     repo_path = clone(url)
     loader = ModelLoader.get()
-    model = loader.load(repo_path, module_name)
+    model = loader.load(repo_path, kwargs)
 
     return model


### PR DESCRIPTION
This pull request contains a very minor change to the zoo module. 

In the current version of the zoo it is not possible to use the `module_name` parameter of model loader. Due to this it is only possible to have one model for each zoo enabled git repository. By enabling the user to specify the module name in the `get_model()` function this restriction is lifted.

With this change it is easier for developers to contribute models to the zoo.