### PR TITLE
batch support (prototype)

### DIFF
--- a/foolbox/__init__.py
+++ b/foolbox/__init__.py
@@ -15,3 +15,4 @@ from . import utils  # noqa: F401
 from . import gradient_estimators  # noqa: F401
 
 from .adversarial import Adversarial  # noqa: F401
+from .yielding_adversarial import YieldingAdversarial  # noqa: F401

--- a/foolbox/adversarial.py
+++ b/foolbox/adversarial.py
@@ -83,8 +83,11 @@ class Adversarial(object):
         self._best_gradient_calls = 0
 
         # check if the original image is already adversarial
+        self.check_original()
+
+    def check_original(self):
         try:
-            self.predictions(original_image)
+            self.predictions(self.__original_image)
         except StopAttack:
             # if a threshold is specified and the original input is
             # misclassified, this can already cause a StopAttack
@@ -99,7 +102,7 @@ class Adversarial(object):
         self._best_prediction_calls = 0
         self._best_gradient_calls = 0
 
-        self.predictions(self.__original_image)
+        self.check_original()
 
     @property
     def image(self):

--- a/foolbox/attacks/base.py
+++ b/foolbox/attacks/base.py
@@ -11,6 +11,7 @@ else:  # pragma: no cover
     ABC = abc.ABCMeta('ABC', (), {})
 
 from ..adversarial import Adversarial
+from ..yielding_adversarial import YieldingAdversarial
 from ..adversarial import StopAttack
 from ..criteria import Misclassification
 from ..distances import MSE
@@ -101,7 +102,11 @@ def call_decorator(call_fn):
     def wrapper(self, input_or_adv, label=None, unpack=True, **kwargs):
         assert input_or_adv is not None
 
-        if isinstance(input_or_adv, Adversarial):
+        if isinstance(input_or_adv, YieldingAdversarial):
+            raise ValueError('If you pass an Adversarial instance, it must not'
+                             ' be a YieldingAdversarial instance when calling'
+                             ' non-batch-supporting attacks like this one.')
+        elif isinstance(input_or_adv, Adversarial):
             a = input_or_adv
             if label is not None:
                 raise ValueError('Label must not be passed when input_or_adv'
@@ -134,7 +139,72 @@ def call_decorator(call_fn):
                           ' is already reached')
         else:
             try:
-                _ = call_fn(self, a, label=None, unpack=None, **kwargs)
+                _ = call_fn(
+                    self, a, label=None, unpack=None, **kwargs)
+                assert _ is None, 'decorated __call__ method must return None'
+            except StopAttack:
+                # if a threshold is specified, StopAttack will be thrown
+                # when the treshold is reached; thus we can do early
+                # stopping of the attack
+                logging.info('threshold reached, stopping attack')
+
+        if a.image is None:
+            warnings.warn('{} did not find an adversarial, maybe the model'
+                          ' or the criterion is not supported by this'
+                          ' attack.'.format(self.name()))
+
+        if unpack:
+            return a.image
+        else:
+            return a
+
+    return wrapper
+
+
+def generator_call_decorator(call_fn):
+    @functools.wraps(call_fn)
+    def wrapper(self, input_or_adv, label=None, unpack=True, **kwargs):
+        assert input_or_adv is not None
+
+        if isinstance(input_or_adv, YieldingAdversarial):
+            a = input_or_adv
+            if label is not None:
+                raise ValueError('Label must not be passed when input_or_adv'
+                                 ' is an Adversarial instance')
+        elif isinstance(input_or_adv, Adversarial):
+            raise ValueError('If you pass an Adversarial instance, it must'
+                             ' be a YieldingAdversarial instance when calling'
+                             ' batch-supporting attacks like this one.')
+        else:
+            if label is None:
+                raise ValueError('Label must be passed when input_or_adv is'
+                                 ' not an Adversarial instance')
+            else:
+                model = self._default_model
+                criterion = self._default_criterion
+                distance = self._default_distance
+                threshold = self._default_threshold
+                if model is None or criterion is None:
+                    raise ValueError('The attack needs to be initialized'
+                                     ' with a model and a criterion or it'
+                                     ' needs to be called with an Adversarial'
+                                     ' instance.')
+                a = YieldingAdversarial(model, criterion, input_or_adv, label,
+                                        distance=distance, threshold=threshold)
+
+        assert a is not None
+
+        if a.distance.value == 0.:
+            warnings.warn('Not running the attack because the original input'
+                          ' is already misclassified and the adversarial thus'
+                          ' has a distance of 0.')
+        elif a.reached_threshold():
+            warnings.warn('Not running the attack because the given treshold'
+                          ' is already reached')
+        else:
+            try:
+                _ = yield from call_fn(
+                    self, a, label=None, unpack=None, **kwargs)
                 assert _ is None, 'decorated __call__ method must return None'
             except StopAttack:
                 # if a threshold is specified, StopAttack will be thrown

--- a/foolbox/attacks/iterative_projected_gradient.py
+++ b/foolbox/attacks/iterative_projected_gradient.py
@@ -5,7 +5,7 @@ import logging
 import warnings
 
 from .base import Attack
-from .base import call_decorator
+from .base import generator_call_decorator
 from .. import distances
 from ..utils import crossentropy
 from .. import nprng
@@ -61,13 +61,15 @@ class IterativeProjectedGradientBaseAttack(Attack):
                 k = 20
             else:
                 k = int(binary_search)
-            return self._run_binary_search(
+            yield from self._run_binary_search(
                 a, epsilon, stepsize, iterations,
                 random_start, targeted, class_, return_early, k=k)
+            return
         else:
-            return self._run_one(
+            success = yield from self._run_one(
                 a, epsilon, stepsize, iterations,
                 random_start, targeted, class_, return_early)
+            return success
 
     def _run_binary_search(self, a, epsilon, stepsize, iterations,
                            random_start, targeted, class_, return_early, k):
@@ -76,12 +78,14 @@ class IterativeProjectedGradientBaseAttack(Attack):
 
         def try_epsilon(epsilon):
             stepsize = factor * epsilon
-            return self._run_one(
+            success = yield from self._run_one(
                 a, epsilon, stepsize, iterations,
                 random_start, targeted, class_, return_early)
+            return success
 
         for i in range(k):
-            if try_epsilon(epsilon):
+            success = yield from try_epsilon(epsilon)
+            if success:
                 logging.info('successful for eps = {}'.format(epsilon))
                 break
             logging.info('not successful for eps = {}'.format(epsilon))
@@ -95,7 +99,8 @@ class IterativeProjectedGradientBaseAttack(Attack):
 
         for i in range(k):
             epsilon = (good + bad) / 2
-            if try_epsilon(epsilon):
+            success = yield from try_epsilon(epsilon)
+            if success:
                 good = epsilon
                 logging.info('successful for eps = {}'.format(epsilon))
             else:
@@ -123,7 +128,7 @@ class IterativeProjectedGradientBaseAttack(Attack):
 
         success = False
         for _ in range(iterations):
-            gradient = self._gradient(a, x, class_, strict=strict)
+            gradient = yield from self._gradient(a, x, class_, strict=strict)
             # non-strict only for the first call and
             # only if random_start is True
             strict = True
@@ -138,7 +143,7 @@ class IterativeProjectedGradientBaseAttack(Attack):
 
             x = np.clip(x, min_, max_)
 
-            logits, is_adversarial = a.predictions(x)
+            logits, is_adversarial = yield from a.predictions(x)
             if logging.getLogger().isEnabledFor(logging.DEBUG):
                 if targeted:
                     ce = crossentropy(a.original_class, logits)
@@ -156,7 +161,7 @@ class IterativeProjectedGradientBaseAttack(Attack):
 
 class LinfinityGradientMixin(object):
     def _gradient(self, a, x, class_, strict=True):
-        gradient = a.gradient(x, class_, strict=strict)
+        gradient = yield from a.gradient(x, class_, strict=strict)
         gradient = np.sign(gradient)
         min_, max_ = a.bounds()
         gradient = (max_ - min_) * gradient
@@ -165,7 +170,7 @@ class LinfinityGradientMixin(object):
 
 class L1GradientMixin(object):
     def _gradient(self, a, x, class_, strict=True):
-        gradient = a.gradient(x, class_, strict=strict)
+        gradient = yield from a.gradient(x, class_, strict=strict)
         # using mean to make range of epsilons comparable to Linf
         gradient = gradient / np.mean(np.abs(gradient))
         min_, max_ = a.bounds()
@@ -175,7 +180,7 @@ class L1GradientMixin(object):
 
 class L2GradientMixin(object):
     def _gradient(self, a, x, class_, strict=True):
-        gradient = a.gradient(x, class_, strict=strict)
+        gradient = yield from a.gradient(x, class_, strict=strict)
         # using mean to make range of epsilons comparable to Linf
         gradient = gradient / np.sqrt(np.mean(np.square(gradient)))
         min_, max_ = a.bounds()
@@ -266,7 +271,7 @@ class LinfinityBasicIterativeAttack(
 
     """
 
-    @call_decorator
+    @generator_call_decorator
     def __call__(self, input_or_adv, label=None, unpack=True,
                  binary_search=True,
                  epsilon=0.3,
@@ -321,9 +326,9 @@ class LinfinityBasicIterativeAttack(
 
         assert epsilon > 0
 
-        self._run(a, binary_search,
-                  epsilon, stepsize, iterations,
-                  random_start, return_early)
+        yield from self._run(a, binary_search,
+                             epsilon, stepsize, iterations,
+                             random_start, return_early)
 
 
 BasicIterativeMethod = LinfinityBasicIterativeAttack
@@ -343,7 +348,7 @@ class L1BasicIterativeAttack(
 
     """
 
-    @call_decorator
+    @generator_call_decorator
     def __call__(self, input_or_adv, label=None, unpack=True,
                  binary_search=True,
                  epsilon=0.3,
@@ -398,9 +403,9 @@ class L1BasicIterativeAttack(
 
         assert epsilon > 0
 
-        self._run(a, binary_search,
-                  epsilon, stepsize, iterations,
-                  random_start, return_early)
+        yield from self._run(a, binary_search,
+                             epsilon, stepsize, iterations,
+                             random_start, return_early)
 
 
 class L2BasicIterativeAttack(
@@ -416,7 +421,7 @@ class L2BasicIterativeAttack(
 
     """
 
-    @call_decorator
+    @generator_call_decorator
     def __call__(self, input_or_adv, label=None, unpack=True,
                  binary_search=True,
                  epsilon=0.3,
@@ -471,9 +476,9 @@ class L2BasicIterativeAttack(
 
         assert epsilon > 0
 
-        self._run(a, binary_search,
-                  epsilon, stepsize, iterations,
-                  random_start, return_early)
+        yield from self._run(a, binary_search,
+                             epsilon, stepsize, iterations,
+                             random_start, return_early)
 
 
 class ProjectedGradientDescentAttack(
@@ -503,7 +508,7 @@ class ProjectedGradientDescentAttack(
 
     """
 
-    @call_decorator
+    @generator_call_decorator
     def __call__(self, input_or_adv, label=None, unpack=True,
                  binary_search=True,
                  epsilon=0.3,
@@ -558,9 +563,9 @@ class ProjectedGradientDescentAttack(
 
         assert epsilon > 0
 
-        self._run(a, binary_search,
-                  epsilon, stepsize, iterations,
-                  random_start, return_early)
+        yield from self._run(a, binary_search,
+                             epsilon, stepsize, iterations,
+                             random_start, return_early)
 
 
 ProjectedGradientDescent = ProjectedGradientDescentAttack
@@ -587,7 +592,7 @@ class RandomStartProjectedGradientDescentAttack(
 
     """
 
-    @call_decorator
+    @generator_call_decorator
     def __call__(self, input_or_adv, label=None, unpack=True,
                  binary_search=True,
                  epsilon=0.3,
@@ -642,9 +647,9 @@ class RandomStartProjectedGradientDescentAttack(
 
         assert epsilon > 0
 
-        self._run(a, binary_search,
-                  epsilon, stepsize, iterations,
-                  random_start, return_early)
+        yield from self._run(a, binary_search,
+                             epsilon, stepsize, iterations,
+                             random_start, return_early)
 
 
 RandomProjectedGradientDescent = RandomStartProjectedGradientDescentAttack
@@ -672,7 +677,7 @@ class MomentumIterativeAttack(
 
     def _gradient(self, a, x, class_, strict=True):
         # get current gradient
-        gradient = a.gradient(x, class_, strict=strict)
+        gradient = yield from a.gradient(x, class_, strict=strict)
         gradient = gradient / max(1e-12, np.mean(np.abs(gradient)))
 
         # combine with history of gradient as new history
@@ -690,9 +695,11 @@ class MomentumIterativeAttack(
         # reset momentum history every time we restart
         # gradient descent
         self._momentum_history = 0
-        return super(MomentumIterativeAttack, self)._run_one(*args, **kwargs)
+        success = yield from super(MomentumIterativeAttack, self)._run_one(
+            *args, **kwargs)
+        return success
 
-    @call_decorator
+    @generator_call_decorator
     def __call__(self, input_or_adv, label=None, unpack=True,
                  binary_search=True,
                  epsilon=0.3,
@@ -751,9 +758,9 @@ class MomentumIterativeAttack(
 
         self._decay_factor = decay_factor
 
-        self._run(a, binary_search,
-                  epsilon, stepsize, iterations,
-                  random_start, return_early)
+        yield from self._run(a, binary_search,
+                             epsilon, stepsize, iterations,
+                             random_start, return_early)
 
 
 MomentumIterativeMethod = MomentumIterativeAttack

--- a/foolbox/batching.py
+++ b/foolbox/batching.py
@@ -1,0 +1,102 @@
+import logging
+import numpy as np
+import itertools
+from .distances import MSE
+from .yielding_adversarial import YieldingAdversarial
+
+
+def run_serial_attack(create_attack_fn, model, criterion, inputs, labels,
+                      distance=MSE, threshold=None, verbose=False):
+    advs = [YieldingAdversarial(model, criterion, x, label,
+                                distance=distance, threshold=threshold, verbose=verbose)  # noqa: E501
+            for x, label in zip(inputs, labels)]
+    attacks = [create_attack_fn()(adv) for adv in advs]
+
+    for i, attack in enumerate(attacks):
+        result = None
+        while True:
+            try:
+                x = attack.send(result)
+            except StopIteration:
+                break
+            method, args = x[0], x[1:]
+            method = {
+                'predictions': model.predictions,
+                'gradient': model.gradient,
+                'backward': model.backward,
+            }[method]
+            result = method(*args)
+            assert result is not None
+        logging.info(f'{i + 1} of {len(advs)} attacks completed')
+    return advs
+
+
+def run_parallel_attack(create_attack_fn, model, criterion, inputs, labels,
+                        distance=MSE, threshold=None, verbose=False):
+    advs = [YieldingAdversarial(model, criterion, x, label,
+                                distance=distance, threshold=threshold, verbose=verbose)  # noqa: E501
+            for x, label in zip(inputs, labels)]
+    attacks = [create_attack_fn()(adv) for adv in advs]
+
+    predictions = [None for _ in attacks]
+    gradients = []
+    backwards = []
+    results = itertools.chain(predictions, gradients, backwards)
+
+    while True:
+        attacks_requesting_predictions = []
+        predictions_args = []
+        attacks_requesting_gradients = []
+        gradients_args = []
+        attacks_requesting_backwards = []
+        backwards_args = []
+        for attack, result in zip(attacks, results):
+            try:
+                x = attack.send(result)
+            except StopIteration:
+                continue
+            method, args = x[0], x[1:]
+            if method == 'predictions':
+                attacks_requesting_predictions.append(attack)
+                predictions_args.append(args)
+            elif method == 'gradient':
+                attacks_requesting_gradients.append(attack)
+                gradients_args.append(args)
+            elif method == 'backward':
+                attacks_requesting_backwards.append(attack)
+                backwards_args.append(args)
+            else:
+                assert False
+        N_active_attacks = len(attacks_requesting_predictions) \
+            + len(attacks_requesting_gradients) \
+            + len(attacks_requesting_backwards)
+        if N_active_attacks < len(predictions) + len(gradients) + len(backwards):  # noqa: E501
+            # an attack completed in this iteration
+            logging.info(f'{len(advs) - N_active_attacks} of {len(advs)} attacks completed')  # noqa: E501
+        if N_active_attacks == 0:
+            break
+
+        if len(attacks_requesting_predictions) > 0:
+            logging.debug('calling batch_predictions with', len(attacks_requesting_predictions))  # noqa: E501
+            predictions_args = map(np.stack, zip(*predictions_args))
+            predictions = model.batch_predictions(*predictions_args)
+        else:
+            predictions = []
+
+        if len(attacks_requesting_gradients) > 0:
+            logging.debug('calling batch_gradients with', len(attacks_requesting_gradients))  # noqa: E501
+            gradients_args = map(np.stack, zip(*gradients_args))
+            gradients = model.batch_gradients(*gradients_args)
+        else:
+            gradients = []
+
+        if len(attacks_requesting_backwards) > 0:
+            logging.debug('calling batch_backward with', len(attacks_requesting_backwards))  # noqa: E501
+            backwards_args = map(np.stack, zip(*backwards_args))
+            backwards = model.batch_backward(*backwards_args)
+        else:
+            backwards = []
+
+        attacks = itertools.chain(attacks_requesting_predictions, attacks_requesting_gradients, attacks_requesting_backwards)  # noqa: E501
+        results = itertools.chain(predictions, gradients, backwards)
+    return advs

--- a/foolbox/batching.py
+++ b/foolbox/batching.py
@@ -27,7 +27,7 @@ def run_serial_attack(create_attack_fn, model, criterion, inputs, labels,
             }[method]
             result = method(*args)
             assert result is not None
-        logging.info(f'{i + 1} of {len(advs)} attacks completed')
+        logging.info('{} of {} attacks completed'.format(i + 1, len(advs)))
     return advs
 
 
@@ -72,7 +72,7 @@ def run_parallel_attack(create_attack_fn, model, criterion, inputs, labels,
             + len(attacks_requesting_backwards)
         if N_active_attacks < len(predictions) + len(gradients) + len(backwards):  # noqa: E501
             # an attack completed in this iteration
-            logging.info(f'{len(advs) - N_active_attacks} of {len(advs)} attacks completed')  # noqa: E501
+            logging.info('{} of {} attacks completed'.format(len(advs) - N_active_attacks, len(advs)))  # noqa: E501
         if N_active_attacks == 0:
             break
 

--- a/foolbox/models/base.py
+++ b/foolbox/models/base.py
@@ -249,6 +249,29 @@ class DifferentiableModel(Model):
         _, gradient = self.predictions_and_gradient(image, label)
         return gradient
 
+    def batch_gradients(self, images, labels):
+        """Calculates the gradient of the cross-entropy loss w.r.t. the images.
+
+        Parameters
+        ----------
+        image : `numpy.ndarray`
+            Batch of input with shape as expected by the model.
+        labels : int
+            Reference label used to calculate the gradient.
+
+        Returns
+        -------
+        gradients : `numpy.ndarray`
+            The gradient of the cross-entropy loss w.r.t. the inputs. Will
+            have the same shape as the inputs.
+
+        See Also
+        --------
+        :meth:`gradient`
+
+        """
+        raise NotImplementedError
+
     @abstractmethod
     def backward(self, gradient, image):
         """Backpropagates the gradient of some loss w.r.t. the logits
@@ -271,6 +294,30 @@ class DifferentiableModel(Model):
         See Also
         --------
         :meth:`gradient`
+
+        """
+        raise NotImplementedError
+
+    def batch_backward(self, gradients, images):
+        """Backpropagates the gradient of some loss w.r.t. the logits
+        through the network and returns the gradient of that loss w.r.t
+        to the input images.
+
+        Parameters
+        ----------
+        gradients : `numpy.ndarray`
+            Gradient of some loss w.r.t. the logits.
+        images : `numpy.ndarray`
+            Batch of inputs with shape as expected by the model.
+
+        Returns
+        -------
+        gradients : `numpy.ndarray`
+            The gradient w.r.t the input images.
+
+        See Also
+        --------
+        :meth:`backward`
 
         """
         raise NotImplementedError

--- a/foolbox/models/mxnet_gluon.py
+++ b/foolbox/models/mxnet_gluon.py
@@ -77,6 +77,20 @@ class MXNetGluonModel(DifferentiableModel):
         gradient = self._process_gradient(dpdx, gradient)
         return predictions, gradient
 
+    def batch_gradients(self, images, labels):
+        import mxnet as mx
+        images, dpdx = self._process_input(images)
+        images = mx.nd.array(images, ctx=self._device)
+        labels = mx.nd.array(labels, ctx=self._device)
+        images.attach_grad()
+        with mx.autograd.record(train_mode=False):
+            logits = self._block(images)
+            loss = mx.nd.softmax_cross_entropy(logits, labels)
+        loss.backward(train_mode=False)
+        gradients = images.grad.asnumpy()
+        gradients = self._process_gradient(dpdx, gradients)
+        return gradients
+
     def _loss_fn(self, image, label):
         import mxnet as mx
         image, _ = self._process_input(image)
@@ -89,7 +103,7 @@ class MXNetGluonModel(DifferentiableModel):
         loss.backward(train_mode=False)
         return loss.asnumpy()
 
-    def backward(self, gradient, image):  # pragma: no cover
+    def backward(self, gradient, image):
         # lazy import
         import mxnet as mx
 
@@ -107,5 +121,21 @@ class MXNetGluonModel(DifferentiableModel):
         gradient_array = data_array.grad
         gradient = np.squeeze(gradient_array.asnumpy(), axis=0)
         gradient = self._process_gradient(dpdx, gradient)
-
         return gradient
+
+    def batch_backward(self, gradients, images):
+        # lazy import
+        import mxnet as mx
+
+        assert gradients.ndim == 2
+        images, dpdx = self._process_input(images)
+        images = mx.nd.array(images, ctx=self._device)
+        gradients = mx.nd.array(gradients, ctx=self._device)
+        images.attach_grad()
+        with mx.autograd.record(train_mode=False):
+            logits = self._block(images)
+        assert gradients.shape == logits.shape
+        logits.backward(gradients, train_mode=False)
+        gradients = images.grad.asnumpy()
+        gradients = self._process_gradient(dpdx, gradients)
+        return gradients

--- a/foolbox/models/pytorch.py
+++ b/foolbox/models/pytorch.py
@@ -152,6 +152,41 @@ class PyTorchModel(DifferentiableModel):
 
         return predictions, grad
 
+    def batch_gradients(self, images, labels):
+        # lazy import
+        import torch
+        import torch.nn as nn
+        if self._old_pytorch():  # pragma: no cover
+            from torch.autograd import Variable
+
+        input_shape = images.shape
+        images, dpdx = self._process_input(images)
+        target = np.asarray(labels)
+        target = torch.from_numpy(labels).long().to(self.device)
+        images = torch.from_numpy(images).to(self.device)
+
+        if self._old_pytorch():  # pragma: no cover
+            target = Variable(target)
+            images = Variable(images, requires_grad=True)
+        else:
+            images.requires_grad_()
+
+        predictions = self._model(images)
+        ce = nn.CrossEntropyLoss()
+        loss = ce(predictions, target)
+        loss.backward()
+        grad = images.grad
+
+        if self._old_pytorch():  # pragma: no cover
+            grad = grad.data
+        grad = grad.to("cpu")
+        if not self._old_pytorch():
+            grad = grad.detach()
+        grad = grad.numpy()
+        grad = self._process_gradient(dpdx, grad)
+        assert grad.shape == input_shape
+        return grad
+
     def _loss_fn(self, image, label):
         # lazy import
         import torch
@@ -218,6 +253,49 @@ class PyTorchModel(DifferentiableModel):
             grad = grad.detach()
         grad = grad.numpy()
         grad = np.squeeze(grad, axis=0)
+        grad = self._process_gradient(dpdx, grad)
+        assert grad.shape == input_shape
+
+        return grad
+
+    def batch_backward(self, gradients, images):
+        # lazy import
+        import torch
+        if self._old_pytorch():  # pragma: no cover
+            from torch.autograd import Variable
+
+        assert gradients.ndim == 2
+
+        gradients = torch.from_numpy(gradients).to(self.device)
+        if self._old_pytorch():  # pragma: no cover
+            gradients = Variable(gradients)
+
+        input_shape = images.shape
+        images, dpdx = self._process_input(images)
+        images = torch.from_numpy(images).to(self.device)
+        if self._old_pytorch():  # pragma: no cover
+            images = Variable(images, requires_grad=True)
+        else:
+            images.requires_grad_()
+        predictions = self._model(images)
+
+        assert gradients.dim() == 2
+        assert predictions.dim() == 2
+        assert gradients.size() == predictions.size()
+
+        # loss = torch.dot(predictions, gradients)
+        # loss.backward()
+        # should be the same as predictions.backward(gradient=gradients)
+        predictions.backward(gradient=gradients)
+
+        grad = images.grad
+
+        if self._old_pytorch():  # pragma: no cover
+            grad = grad.data
+        grad = grad.to("cpu")
+        if not self._old_pytorch():
+            grad = grad.detach()
+        grad = grad.numpy()
         grad = self._process_gradient(dpdx, grad)
         assert grad.shape == input_shape
 

--- a/foolbox/models/tensorflow.py
+++ b/foolbox/models/tensorflow.py
@@ -58,17 +58,18 @@ class TensorFlowModel(DifferentiableModel):
             self._images = images
             self._batch_logits = logits
             self._logits = tf.squeeze(logits, axis=0)
-            self._label = tf.placeholder(tf.int64, (), name='label')
+            self._labels = tf.placeholder(tf.int64, (None,), name='labels')
 
             loss = tf.nn.sparse_softmax_cross_entropy_with_logits(
-                labels=self._label[tf.newaxis],
-                logits=self._logits[tf.newaxis])
-            self._loss = tf.squeeze(loss, axis=0)
+                labels=self._labels,
+                logits=self._batch_logits)
+            self._loss = tf.reduce_sum(loss)
             gradients = tf.gradients(loss, images)
             assert len(gradients) == 1
             if gradients[0] is None:
                 gradients[0] = tf.zeros_like(images)
             self._gradient = tf.squeeze(gradients[0], axis=0)
+            self._batch_gradients = gradients[0]
 
             self._bw_gradient_pre = tf.placeholder(tf.float32, self._logits.shape)  # noqa: E501
             bw_loss = tf.reduce_sum(self._logits * self._bw_gradient_pre)
@@ -77,6 +78,14 @@ class TensorFlowModel(DifferentiableModel):
             if bw_gradients[0] is None:
                 bw_gradients[0] = tf.zeros_like(images)
             self._bw_gradient = tf.squeeze(bw_gradients[0], axis=0)
+
+            self._bw_gradients_pre = tf.placeholder(tf.float32, self._batch_logits.shape)  # noqa: E501
+            batch_bw_loss = tf.reduce_sum(self._batch_logits * self._bw_gradients_pre)  # noqa: E501
+            batch_bw_gradients = tf.gradients(batch_bw_loss, images)
+            assert len(batch_bw_gradients) == 1
+            if batch_bw_gradients[0] is None:
+                batch_bw_gradients[0] = tf.zeros_like(images)
+            self._bw_gradients = batch_bw_gradients[0]
 
     @classmethod
     def from_keras(cls, model, bounds, input_shape=None,
@@ -144,7 +153,7 @@ class TensorFlowModel(DifferentiableModel):
             [self._logits, self._gradient],
             feed_dict={
                 self._images: image[np.newaxis],
-                self._label: label})
+                self._labels: np.asarray(label)[np.newaxis]})
         gradient = self._process_gradient(dpdx, gradient)
         return predictions, gradient
 
@@ -154,7 +163,17 @@ class TensorFlowModel(DifferentiableModel):
             self._gradient,
             feed_dict={
                 self._images: image[np.newaxis],
-                self._label: label})
+                self._labels: np.asarray(label)[np.newaxis]})
+        g = self._process_gradient(dpdx, g)
+        return g
+
+    def batch_gradients(self, images, labels):
+        images, dpdx = self._process_input(images)
+        g = self._session.run(
+            self._batch_gradients,
+            feed_dict={
+                self._images: images,
+                self._labels: labels})
         g = self._process_gradient(dpdx, g)
         return g
 
@@ -164,7 +183,7 @@ class TensorFlowModel(DifferentiableModel):
             self._loss,
             feed_dict={
                 self._images: image[np.newaxis],
-                self._label: label})
+                self._labels: np.asarray(label)[np.newaxis]})
         return loss
 
     def backward(self, gradient, image):
@@ -176,6 +195,19 @@ class TensorFlowModel(DifferentiableModel):
             feed_dict={
                 self._images: image[np.newaxis],
                 self._bw_gradient_pre: gradient})
+        g = self._process_gradient(dpdx, g)
+        assert g.shape == input_shape
+        return g
+
+    def batch_backward(self, gradients, images):
+        assert gradients.ndim == 2
+        input_shape = images.shape
+        images, dpdx = self._process_input(images)
+        g = self._session.run(
+            self._bw_gradients,
+            feed_dict={
+                self._images: images,
+                self._bw_gradients_pre: gradients})
         g = self._process_gradient(dpdx, g)
         assert g.shape == input_shape
         return g

--- a/foolbox/tests/conftest.py
+++ b/foolbox/tests/conftest.py
@@ -40,6 +40,7 @@ from foolbox.models import CaffeModel
 from foolbox.models import ModelWithoutGradients
 from foolbox.models import ModelWithEstimatedGradients
 from foolbox import Adversarial
+from foolbox import YieldingAdversarial
 from foolbox.distances import MSE
 from foolbox.distances import Linfinity
 from foolbox.distances import MAE
@@ -285,6 +286,17 @@ def bn_adversarial(bn_criterion, bn_image, bn_label):
     cm_model = contextmanager(bn_model)
     with cm_model() as model:
         yield Adversarial(model, criterion, image, label)
+
+
+@pytest.fixture
+def bn_yielding_adversarial(bn_criterion, bn_image, bn_label):
+    criterion = bn_criterion
+    image = bn_image
+    label = bn_label
+
+    cm_model = contextmanager(bn_model)
+    with cm_model() as model:
+        yield YieldingAdversarial(model, criterion, image, label)
 
 
 @pytest.fixture

--- a/foolbox/tests/test_attacks_carlini_wagner.py
+++ b/foolbox/tests/test_attacks_carlini_wagner.py
@@ -3,8 +3,8 @@ import numpy as np
 from foolbox.attacks import CarliniWagnerL2Attack as Attack
 
 
-def test_untargeted_attack(bn_adversarial):
-    adv = bn_adversarial
+def test_untargeted_attack(bn_yielding_adversarial):
+    adv = bn_yielding_adversarial
     attack = Attack()
     attack(adv, max_iterations=100)
     assert adv.image is not None

--- a/foolbox/yielding_adversarial.py
+++ b/foolbox/yielding_adversarial.py
@@ -1,0 +1,120 @@
+"""
+Provides a class that represents an adversarial example.
+
+"""
+
+from .adversarial import Adversarial
+from .adversarial import StopAttack
+
+
+class YieldingAdversarial(Adversarial):
+    def check_original(self):
+        try:
+            # TODO: this call is still done without batching
+            super(YieldingAdversarial, self).predictions(
+                self._Adversarial__original_image)
+        except StopAttack:
+            # if a threshold is specified and the original input is
+            # misclassified, this can already cause a StopAttack
+            # exception
+            assert self.distance.value == 0.
+
+    def predictions(self, image, strict=True, return_details=False):
+        """Interface to model.predictions for attacks.
+
+        Parameters
+        ----------
+        image : `numpy.ndarray`
+            Single input with shape as expected by the model
+            (without the batch dimension).
+        strict : bool
+            Controls if the bounds for the pixel values should be checked.
+
+        """
+        in_bounds = self.in_bounds(image)
+        assert not strict or in_bounds
+
+        self._total_prediction_calls += 1
+        predictions = yield ('predictions', image)
+        is_adversarial, is_best, distance = self._Adversarial__is_adversarial(
+            image, predictions, in_bounds)
+
+        assert predictions.ndim == 1
+        if return_details:
+            return predictions, is_adversarial, is_best, distance
+        else:
+            return predictions, is_adversarial
+
+    def batch_predictions(
+            self, images, greedy=False, strict=True, return_details=False):
+        raise NotImplementedError
+
+    def gradient(self, image=None, label=None, strict=True):
+        """Interface to model.gradient for attacks.
+
+        Parameters
+        ----------
+        image : `numpy.ndarray`
+            Single input with shape as expected by the model
+            (without the batch dimension).
+            Defaults to the original image.
+        label : int
+            Label used to calculate the loss that is differentiated.
+            Defaults to the original label.
+        strict : bool
+            Controls if the bounds for the pixel values should be checked.
+
+        """
+        assert self.has_gradient()
+
+        if image is None:
+            image = self._Adversarial__original_image
+        if label is None:
+            label = self._Adversarial__original_class
+
+        assert not strict or self.in_bounds(image)
+
+        self._total_gradient_calls += 1
+        gradient = yield ('gradient', image, label)
+
+        assert gradient.shape == image.shape
+        return gradient
+
+    def predictions_and_gradient(
+            self, image=None, label=None, strict=True, return_details=False):
+        raise NotImplementedError
+
+    def backward(self, gradient, image=None, strict=True):
+        """Interface to model.backward for attacks.
+
+        Parameters
+        ----------
+        gradient : `numpy.ndarray`
+            Gradient of some loss w.r.t. the logits.
+        image : `numpy.ndarray`
+            Single input with shape as expected by the model
+            (without the batch dimension).
+
+        Returns
+        -------
+        gradient : `numpy.ndarray`
+            The gradient w.r.t the image.
+
+        See Also
+        --------
+        :meth:`gradient`
+
+        """
+        assert self.has_gradient()
+        assert gradient.ndim == 1
+
+        if image is None:
+            image = self._Adversarial__original_image
+
+        assert not strict or self.in_bounds(image)
+
+        self._total_gradient_calls += 1
+        gradient = yield ('backward', gradient, image)
+
+        assert gradient.shape == image.shape
+        return gradient


### PR DESCRIPTION
This is a prototype of our upcoming batch support, bringing a massive speed-up to Foolbox without the need to rewrite attacks or even changing the attack logic to support batches (which can be very difficult for certain attacks and comes with other disadvantages).

So far, this works with `TensorFlowModel` and `PyTorchModel`. You can try this now using `CarliniWagnerAttack`, `GradientAttack` and similar ones and all `PGD`-like attacks (`BasicIterativeMethod`, `RandomStartProjectedGradientDescentAttack`, etc.).

The current API to try this feature looks like this:

```python3
from foolbox.batching import run_parallel_attack

model = ...
images = ...
labels = ...

attack_create_fn = foolbox.attacks.CarliniWagnerL2Attack  # for example
criterion = foolbox.criteria.Misclassification()  # for example

advs = run_parallel_attack(attack_create_fn, model, criterion, images, labels)
# advs will be a list of Adversarial objects
```

This Jupyter notebook contains a complete example: https://gist.github.com/jonasrauber/140ada5a352cabb3dd0e91b9cd3adf03