### PR TITLE
Dropping support for old PyTorch versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,9 +34,9 @@ before_install:
     - travis_wait travis_retry pip install --upgrade https://github.com/Lasagne/Lasagne/archive/master.zip
     - python -c 'import lasagne; print(lasagne.__version__)'
 
-    - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then travis_wait travis_retry pip install http://download.pytorch.org/whl/cpu/torch-1.0.1.post2-cp27-cp27mu-linux_x86_64.whl; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == 3.5 ]]; then travis_wait travis_retry pip install http://download.pytorch.org/whl/cpu/torch-1.0.1.post2-cp35-cp35m-linux_x86_64.whl; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then travis_wait travis_retry pip install http://download.pytorch.org/whl/cpu/torch-1.0.1.post2-cp36-cp36m-linux_x86_64.whl; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then travis_wait travis_retry pip install http://download.pytorch.org/whl/cpu/torch-1.1.0-cp27-cp27mu-linux_x86_64.whl; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == 3.5 ]]; then travis_wait travis_retry pip install http://download.pytorch.org/whl/cpu/torch-1.1.0-cp35-cp35m-linux_x86_64.whl; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then travis_wait travis_retry pip install http://download.pytorch.org/whl/cpu/torch-1.1.0-cp36-cp36m-linux_x86_64.whl; fi
     - python -c 'import torch; print(torch.__version__)'
 
     - travis_wait travis_retry pip install --upgrade keras>=2.1.5


### PR DESCRIPTION
Removed as it's quite outdated. If we were to reintroduce this, then it should be as a separate `Model` subclass instead of lot's of ifs.