### PR TITLE
Remove Python 2.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ services:
 dist: trusty
 language: python
 python:
-    - 2.7
     - 3.5
     - 3.6
 env:

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ Installation
 
    pip install foolbox
 
-We test using Python 2.7, 3.5 and 3.6. Other Python versions might work as well. **We recommend using Python 3!**
+Foolbox requires Python 3.5 or newer (since Foolbox 2.0).
 
 Documentation
 -------------

--- a/foolbox/models/caffe.py
+++ b/foolbox/models/caffe.py
@@ -6,7 +6,7 @@ from .base import DifferentiableModel
 from .. import utils
 
 
-class CaffeModel(DifferentiableModel):
+class CaffeModel(DifferentiableModel):  # pragma: no cover
     def __init__(self,
                  net,
                  bounds,

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ setup(
         "Intended Audience :: Developers",
         "Intended Audience :: Science/Research",
         "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
@@ -57,6 +56,5 @@ setup(
     install_requires=install_requires,
     extras_require={
         'testing': tests_require,
-        ':python_version == "2.7"': ['future', 'futures'],
     },
 )


### PR DESCRIPTION
This PR removes Python 2.7 only from the tests, but with new features requiring Python 3 it will also stop working.