### PR TITLE
Extend batching methods

### DIFF
--- a/foolbox/batching.py
+++ b/foolbox/batching.py
@@ -7,9 +7,66 @@ from .yielding_adversarial import YieldingAdversarial
 
 def run_sequential(create_attack_fn, model, criterion, inputs, labels,
                    distance=MSE, threshold=None, verbose=False, **kwargs):
-    advs = [YieldingAdversarial(model, criterion, x, label,
-                                distance=distance, threshold=threshold, verbose=verbose)
-            for x, label in zip(inputs, labels)]
+    """
+    Runs the same type of attack vor multiple inputs sequentially without
+    batching them.
+
+    Parameters
+    ----------
+    create_attack_fn : a function returning an :class:`Attack` instance
+        The attack to use.
+    model : a :class:`Model` instance
+        The model that should be fooled by the adversarial.
+    criterion : a :class:`Criterion` class or list of :class:`Criterion` classes
+        The criterion/criteria that determine(s) which inputs are adversarial.
+    inputs :  a :class:`numpy.ndarray`
+        The unperturbed inputs to which the adversarial input should be as close
+        as possible.
+    labels :  a :class:`numpy.ndarray`
+        The ground-truth labels of the unperturbed inputs.
+    distance : a :class:`Distance` class
+        The measure used to quantify how close inputs are.
+    threshold : float or :class:`Distance`
+        If not None, the attack will stop as soon as the adversarial
+        perturbation has a size smaller than this threshold. Can be
+        an instance of the :class:`Distance` class passed to the distance
+        argument, or a float assumed to have the same unit as the
+        the given distance. If None, the attack will simply minimize
+        the distance as good as possible. Note that the threshold only
+        influences early stopping of the attack; the returned adversarial
+        does not necessarily have smaller perturbation size than this
+        threshold; the :class:`Adversarial`.`reached_threshold()` method can
+         be used to check
+        if the threshold has been reached.
+    verbose : bool
+        Whether the adversarial examples should be created in verbose mode.
+    kwargs : dict
+         The optional keywords passed to create_attack_fn.
+
+    Returns
+    -------
+    The list of generated adversarial examples.
+    """
+
+    assert len(inputs) == len(labels), 'The number of inputs must match the number of labels.'  # noqa: E501
+
+    # if only one criterion has been passed use the same one for all inputs
+    if not isinstance(criterion, (list, tuple)):
+        criterion = [criterion] * len(inputs)
+    else:
+        assert len(criterion) == len(inputs), 'The number of criteria must match the number of inputs.'  # noqa: E501
+
+    # if only one distance has been passed use the same one for all inputs
+    if not isinstance(distance, (list, tuple)):
+        distance = [distance] * len(inputs)
+    else:
+        assert len(distance) == len(inputs), 'The number of distances must match the number of inputs.'  # noqa: E501
+
+    advs = [YieldingAdversarial(model, _criterion, x, label,
+                                distance=_distance, threshold=threshold,
+                                verbose=verbose)
+            for _criterion, _distance, x, label in zip(criterion, distance,
+                                                       inputs, labels)]
     attacks = [create_attack_fn().as_generator(adv, **kwargs) for adv in advs]
 
     supported_methods = {
@@ -36,9 +93,67 @@ def run_sequential(create_attack_fn, model, criterion, inputs, labels,
 
 def run_parallel(create_attack_fn, model, criterion, inputs, labels,
                  distance=MSE, threshold=None, verbose=False, **kwargs):
-    advs = [YieldingAdversarial(model, criterion, x, label,
-                                distance=distance, threshold=threshold, verbose=verbose)
-            for x, label in zip(inputs, labels)]
+    """
+        Runs the same type of attack vor multiple inputs in parallel by
+        batching them.
+
+        Parameters
+        ----------
+        create_attack_fn : a function returning an :class:`Attack` instance
+            The attack to use.
+        model : a :class:`Model` instance
+            The model that should be fooled by the adversarial.
+        criterion : a :class:`Criterion` class or list of :class:`Criterion` classes
+            The criterion/criteria that determine(s) which inputs are adversarial.
+        inputs :  a :class:`numpy.ndarray`
+            The unperturbed inputs to which the adversarial input should be as close
+            as possible.
+        labels :  a :class:`numpy.ndarray`
+            The ground-truth labels of the unperturbed inputs.
+        distance : a :class:`Distance` class or list of :class:`Distance` classes
+            The measure(s) used to quantify how close inputs are.
+        threshold : float or :class:`Distance`
+            If not None, the attack will stop as soon as the adversarial
+            perturbation has a size smaller than this threshold. Can be
+            an instance of the :class:`Distance` class passed to the distance
+            argument, or a float assumed to have the same unit as the
+            the given distance. If None, the attack will simply minimize
+            the distance as good as possible. Note that the threshold only
+            influences early stopping of the attack; the returned adversarial
+            does not necessarily have smaller perturbation size than this
+            threshold; the :class:`Adversarial`.`reached_threshold()` method can
+             be used to check
+            if the threshold has been reached.
+        verbose : bool
+            Whether the adversarial examples should be created in verbose mode.
+        kwargs : dict
+             The optional keywords passed to create_attack_fn.
+
+        Returns
+        -------
+        The list of generated adversarial examples.
+        """
+
+    assert len(inputs) == len(labels), 'The number of inputs must match the number of labels.'  # noqa: E501
+
+    # if only one criterion has been passed use the same one for all inputs
+    if not isinstance(criterion, (list, tuple)):
+        criterion = [criterion] * len(inputs)
+    else:
+        assert len(criterion) == len(inputs), 'The number of criteria must match the number of inputs.'  # noqa: E501
+
+    # if only one distance has been passed use the same one for all inputs
+    if not isinstance(distance, (list, tuple)):
+        distance = [distance] * len(inputs)
+    else:
+        assert len(distance) == len(
+            inputs), 'The number of distances must match the number of inputs.'  # noqa: E501
+
+    advs = [YieldingAdversarial(model, _criterion, x, label,
+                                distance=_distance, threshold=threshold,
+                                verbose=verbose)
+            for _criterion, _distance, x, label in zip(criterion, distance,
+                                                       inputs, labels)]
     attacks = [create_attack_fn().as_generator(adv, **kwargs) for adv in advs]
 
     predictions = [None for _ in attacks]
@@ -69,35 +184,36 @@ def run_parallel(create_attack_fn, model, criterion, inputs, labels,
                 attacks_requesting_backwards.append(attack)
                 backwards_args.append(args)
             elif method == 'forward_and_gradient_one':
-                raise NotImplementedError('batching support for forward_and_gradient_one'
-                                          ' not yet implemented; please open an issue')
+                raise NotImplementedError('batching support for forward_and_'
+                                          'gradient_one not yet implemented; '
+                                          'please open an issue')
             else:
                 assert False
-        N_active_attacks = len(attacks_requesting_predictions) \
+        n_active_attacks = len(attacks_requesting_predictions) \
             + len(attacks_requesting_gradients) \
             + len(attacks_requesting_backwards)
-        if N_active_attacks < len(predictions) + len(gradients) + len(backwards):  # noqa: E501
+        if n_active_attacks < len(predictions) + len(gradients) + len(backwards):  # noqa: E501
             # an attack completed in this iteration
-            logging.info('{} of {} attacks completed'.format(len(advs) - N_active_attacks, len(advs)))  # noqa: E501
-        if N_active_attacks == 0:
+            logging.info('{} of {} attacks completed'.format(len(advs) - n_active_attacks, len(advs)))  # noqa: E501
+        if n_active_attacks == 0:
             break
 
         if len(attacks_requesting_predictions) > 0:
-            logging.debug('calling forward with', len(attacks_requesting_predictions))  # noqa: E501
+            logging.debug('calling forward with {}'.format(len(attacks_requesting_predictions)))  # noqa: E501
             predictions_args = map(np.stack, zip(*predictions_args))
             predictions = model.forward(*predictions_args)
         else:
             predictions = []
 
         if len(attacks_requesting_gradients) > 0:
-            logging.debug('calling gradient with', len(attacks_requesting_gradients))  # noqa: E501
+            logging.debug('calling gradient with {}'.format(len(attacks_requesting_gradients)))  # noqa: E501
             gradients_args = map(np.stack, zip(*gradients_args))
             gradients = model.gradient(*gradients_args)
         else:
             gradients = []
 
         if len(attacks_requesting_backwards) > 0:
-            logging.debug('calling backward with', len(attacks_requesting_backwards))  # noqa: E501
+            logging.debug('calling backward with {}'.format(len(attacks_requesting_backwards)))  # noqa: E501
             backwards_args = map(np.stack, zip(*backwards_args))
             backwards = model.backward(*backwards_args)
         else:

--- a/foolbox/batching.py
+++ b/foolbox/batching.py
@@ -146,8 +146,7 @@ def run_parallel(create_attack_fn, model, criterion, inputs, labels,
     if not isinstance(distance, (list, tuple)):
         distance = [distance] * len(inputs)
     else:
-        assert len(distance) == len(
-            inputs), 'The number of distances must match the number of inputs.'  # noqa: E501
+        assert len(distance) == len(inputs), 'The number of distances must match the number of inputs.'  # noqa: E501
 
     advs = [YieldingAdversarial(model, _criterion, x, label,
                                 distance=_distance, threshold=threshold,

--- a/foolbox/tests/test_batching.py
+++ b/foolbox/tests/test_batching.py
@@ -20,14 +20,14 @@ def test_run_parallel(bn_model, bn_criterion, bn_images, bn_labels):
 
 def test_run_parallel_invalid_arguments(bn_model, bn_criterion, bn_images,
                                         bn_labels):
-    bn_labels_wrong = bn_labels[[0]]
+    labels_wrong = bn_labels[[0]]
     criteria_wrong = [bn_criterion] * (len(bn_images) + 1)
     distances_wrong = [MSE] * (len(bn_images) + 1)
 
     # test too few labels
     with pytest.raises(AssertionError):
         run_parallel(Attack, bn_model, bn_criterion, bn_images,
-                     bn_labels_wrong)
+                     labels_wrong)
 
     # test too many criteria
     with pytest.raises(AssertionError):
@@ -36,8 +36,8 @@ def test_run_parallel_invalid_arguments(bn_model, bn_criterion, bn_images,
 
     # test too many distances
     with pytest.raises(AssertionError):
-        run_parallel(Attack, bn_model, distances_wrong, bn_images,
-                     bn_labels)
+        run_parallel(Attack, bn_model, bn_criterion, bn_images,
+                     bn_labels, distance=distances_wrong)
 
 
 def test_run_sequential(bn_model, bn_criterion, bn_images, bn_labels):
@@ -52,14 +52,14 @@ def test_run_sequential(bn_model, bn_criterion, bn_images, bn_labels):
 
 def test_run_sequential_invalid_arguments(bn_model, bn_criterion, bn_images,
                                           bn_labels):
-    bn_labels_wrong = bn_labels[[0]]
+    labels_wrong = bn_labels[[0]]
     criteria_wrong = [bn_criterion] * (len(bn_images) + 1)
     distances_wrong = [MSE] * (len(bn_images) + 1)
 
     # test too few labels
     with pytest.raises(AssertionError):
         run_sequential(Attack, bn_model, bn_criterion, bn_images,
-                       bn_labels_wrong)
+                       labels_wrong)
 
     # test too many criteria
     with pytest.raises(AssertionError):
@@ -68,5 +68,5 @@ def test_run_sequential_invalid_arguments(bn_model, bn_criterion, bn_images,
 
     # test too many distances
     with pytest.raises(AssertionError):
-        run_sequential(Attack, bn_model, distances_wrong, bn_images,
-                       bn_labels)
+        run_sequential(Attack, bn_model, bn_criterion, bn_images,
+                       bn_labels, distance=distances_wrong)

--- a/foolbox/tests/test_batching.py
+++ b/foolbox/tests/test_batching.py
@@ -1,9 +1,11 @@
 import numpy as np
+import pytest
 
 from foolbox.batch_attacks import GradientAttack as Attack
 
 from foolbox import run_parallel
 from foolbox import run_sequential
+from foolbox.distances import MSE
 
 
 def test_run_parallel(bn_model, bn_criterion, bn_images, bn_labels):
@@ -16,6 +18,28 @@ def test_run_parallel(bn_model, bn_criterion, bn_images, bn_labels):
     assert np.all(advs1 == advs2)
 
 
+def test_run_parallel_invalid_arguments(bn_model, bn_criterion, bn_images,
+                                        bn_labels):
+    bn_labels_wrong = bn_labels[[0]]
+    criteria_wrong = [bn_criterion] * (len(bn_images) + 1)
+    distances_wrong = [MSE] * (len(bn_images) + 1)
+
+    # test too few labels
+    with pytest.raises(AssertionError):
+        run_parallel(Attack, bn_model, bn_criterion, bn_images,
+                     bn_labels_wrong)
+
+    # test too many criteria
+    with pytest.raises(AssertionError):
+        run_parallel(Attack, bn_model, criteria_wrong, bn_images,
+                     bn_labels)
+
+    # test too many distances
+    with pytest.raises(AssertionError):
+        run_parallel(Attack, bn_model, distances_wrong, bn_images,
+                     bn_labels)
+
+
 def test_run_sequential(bn_model, bn_criterion, bn_images, bn_labels):
     attack = Attack(bn_model, bn_criterion)
     advs1 = attack(bn_images, bn_labels)
@@ -24,3 +48,25 @@ def test_run_sequential(bn_model, bn_criterion, bn_images, bn_labels):
     advs2 = np.stack([a.perturbed for a in advs2])
 
     assert np.all(advs1 == advs2)
+
+
+def test_run_sequential_invalid_arguments(bn_model, bn_criterion, bn_images,
+                                          bn_labels):
+    bn_labels_wrong = bn_labels[[0]]
+    criteria_wrong = [bn_criterion] * (len(bn_images) + 1)
+    distances_wrong = [MSE] * (len(bn_images) + 1)
+
+    # test too few labels
+    with pytest.raises(AssertionError):
+        run_sequential(Attack, bn_model, bn_criterion, bn_images,
+                       bn_labels_wrong)
+
+    # test too many criteria
+    with pytest.raises(AssertionError):
+        run_sequential(Attack, bn_model, criteria_wrong, bn_images,
+                       bn_labels)
+
+    # test too many distances
+    with pytest.raises(AssertionError):
+        run_sequential(Attack, bn_model, distances_wrong, bn_images,
+                       bn_labels)


### PR DESCRIPTION
This PR will add support for multiple distances and criteria in the same call of `run_sequential` and `run_parallel`. This allows one to use the batch mode to find targeted adversarial examples with different targets for each example. Furthermore, docstrings have been added to these functions.