### PR TITLE
Add Sparse L1 Attack

### DIFF
--- a/docs/modules/attacks.rst
+++ b/docs/modules/attacks.rst
@@ -47,6 +47,7 @@
    EADAttack
    DecoupledDirectionNormL2Attack
    SparseFoolAttack
+   SparseL1BasicIterativeAttack
 
 
 .. rubric:: :doc:`attacks/score`

--- a/docs/modules/attacks/gradient.rst
+++ b/docs/modules/attacks/gradient.rst
@@ -118,3 +118,8 @@ Gradient-based attacks
 .. autoclass:: SparseFoolAttack
    :members:
    :special-members:
+
+.. autoclass:: SparseL1BasicIterativeAttack
+   :members:
+   :special-members:
+

--- a/foolbox/batch_attacks/__init__.py
+++ b/foolbox/batch_attacks/__init__.py
@@ -10,3 +10,4 @@ from .iterative_projected_gradient import L2BasicIterativeAttack
 from .iterative_projected_gradient import ProjectedGradientDescentAttack, ProjectedGradientDescent, PGD
 from .iterative_projected_gradient import RandomStartProjectedGradientDescentAttack, RandomProjectedGradientDescent, RandomPGD
 from .iterative_projected_gradient import MomentumIterativeAttack, MomentumIterativeMethod
+from .iterative_projected_gradient import SparseL1BasicIterativeAttack

--- a/foolbox/batch_attacks/iterative_projected_gradient.py
+++ b/foolbox/batch_attacks/iterative_projected_gradient.py
@@ -526,7 +526,7 @@ class SparseL1BasicIterativeAttack(
 
         assert epsilon > 0
 
-        assert 1.0 <= q <= 99.0, '`q` must be in [0, 100).'
+        assert 0 <= q < 100.0, '`q` must be in [0, 100).'
 
         yield from self._run(a, binary_search,
                              epsilon, stepsize, iterations,

--- a/foolbox/batch_attacks/iterative_projected_gradient.py
+++ b/foolbox/batch_attacks/iterative_projected_gradient.py
@@ -78,7 +78,6 @@ class IterativeProjectedGradientBaseAttack(BatchAttack):
             success = yield from self._run_one(
                 a, epsilon, optimizer, iterations,
                 random_start, targeted, class_, return_early)
-
             return success
 
     def _run_binary_search(self, a, epsilon, stepsize, iterations,
@@ -94,7 +93,6 @@ class IterativeProjectedGradientBaseAttack(BatchAttack):
             success = yield from self._run_one(
                 a, epsilon, optimizer, iterations,
                 random_start, targeted, class_, return_early)
-
             return success
 
         for i in range(k):

--- a/foolbox/batch_attacks/iterative_projected_gradient.py
+++ b/foolbox/batch_attacks/iterative_projected_gradient.py
@@ -77,7 +77,8 @@ class IterativeProjectedGradientBaseAttack(BatchAttack):
 
             success = yield from self._run_one(
                 a, epsilon, optimizer, iterations,
-                random_start, targeted, class_, return_early)
+                random_start, targeted, class_, return_early,
+                gradient_kwargs)
             return success
 
     def _run_binary_search(self, a, epsilon, stepsize, iterations,
@@ -92,7 +93,8 @@ class IterativeProjectedGradientBaseAttack(BatchAttack):
 
             success = yield from self._run_one(
                 a, epsilon, optimizer, iterations,
-                random_start, targeted, class_, return_early)
+                random_start, targeted, class_, return_early,
+                gradient_kwargs)
             return success
 
         for i in range(k):
@@ -459,6 +461,7 @@ class SparseL1BasicIterativeAttack(
         SparseL1GradientMixin,
         L1ClippingMixin,
         L1DistanceCheckMixin,
+        GDOptimizerMixin,
         IterativeProjectedGradientBaseAttack):
 
     """Sparse version of the Basic Iterative Method

--- a/foolbox/batch_attacks/iterative_projected_gradient.py
+++ b/foolbox/batch_attacks/iterative_projected_gradient.py
@@ -46,7 +46,7 @@ class IterativeProjectedGradientBaseAttack(BatchAttack):
 
     def _run(self, a, binary_search,
              epsilon, stepsize, iterations,
-             random_start, return_early):
+             random_start, return_early, gradient_kwargs={}):
         if not a.has_gradient():
             warnings.warn('applied gradient-based attack to model that'
                           ' does not provide gradients')
@@ -63,16 +63,19 @@ class IterativeProjectedGradientBaseAttack(BatchAttack):
                 k = int(binary_search)
             yield from self._run_binary_search(
                 a, epsilon, stepsize, iterations,
-                random_start, targeted, class_, return_early, k=k)
+                random_start, targeted, class_, return_early, k=k,
+                gradient_kwargs=gradient_kwargs)
             return
         else:
             success = yield from self._run_one(
                 a, epsilon, stepsize, iterations,
-                random_start, targeted, class_, return_early)
+                random_start, targeted, class_, return_early,
+                gradient_kwargs)
             return success
 
     def _run_binary_search(self, a, epsilon, stepsize, iterations,
-                           random_start, targeted, class_, return_early, k):
+                           random_start, targeted, class_, return_early, k,
+                           gradient_kwargs):
 
         factor = stepsize / epsilon
 
@@ -80,7 +83,8 @@ class IterativeProjectedGradientBaseAttack(BatchAttack):
             stepsize = factor * epsilon
             success = yield from self._run_one(
                 a, epsilon, stepsize, iterations,
-                random_start, targeted, class_, return_early)
+                random_start, targeted, class_, return_early,
+                gradient_kwargs)
             return success
 
         for i in range(k):
@@ -108,7 +112,8 @@ class IterativeProjectedGradientBaseAttack(BatchAttack):
                 logging.info('not successful for eps = {}'.format(epsilon))
 
     def _run_one(self, a, epsilon, stepsize, iterations,
-                 random_start, targeted, class_, return_early):
+                 random_start, targeted, class_, return_early,
+                 gradient_kwargs):
         min_, max_ = a.bounds()
         s = max_ - min_
 
@@ -128,7 +133,8 @@ class IterativeProjectedGradientBaseAttack(BatchAttack):
 
         success = False
         for _ in range(iterations):
-            gradient = yield from self._gradient(a, x, class_, strict=strict)
+            gradient = yield from self._gradient(a, x, class_, strict=strict,
+                                                 **gradient_kwargs)
             # non-strict only for the first call and
             # only if random_start is True
             strict = True
@@ -163,6 +169,43 @@ class LinfinityGradientMixin(object):
     def _gradient(self, a, x, class_, strict=True):
         gradient = yield from a.gradient_one(x, class_, strict=strict)
         gradient = np.sign(gradient)
+        min_, max_ = a.bounds()
+        gradient = (max_ - min_) * gradient
+        return gradient
+
+
+class SparseL1GradientMixin(object):
+    """Calculates a sparse L1 gradient introduced in [1]_.
+
+         References
+        ----------
+        .. [1] Florian Tramèr, Dan Boneh,
+               "Adversarial Training and Robustness for Multiple Perturbations",
+               https://arxiv.org/abs/1904.13000
+
+        """
+
+    def _gradient(self, a, x, class_, q, strict=True):
+        gradient = yield from a.gradient_one(x, class_, strict=strict)
+        # make gradient sparse
+        # mask all entries of the gradient that are part of the q'th percentile
+        # calculate how many entries are part of the q'th percentile
+        absolute_q = int(np.floor(np.prod(gradient.shape) * q))
+
+        abs_grad = np.abs(gradient)
+        sorted_abs_grad = np.sort(abs_grad.flatten())
+        gradient_threshold = sorted_abs_grad[absolute_q]
+        gradient_percentile_mask = abs_grad <= gradient_threshold
+        e = np.sign(gradient)
+        e[gradient_percentile_mask] = 0
+
+        # using mean to make range of epsilons comparable to Linf
+        normalization = np.mean(np.abs(e))
+        # make sure that we do not try to calculate 0/0
+        if normalization == 0:
+            normalization = 1
+
+        gradient = e / normalization
         min_, max_ = a.bounds()
         gradient = (max_ - min_) * gradient
         return gradient
@@ -394,6 +437,83 @@ class L1BasicIterativeAttack(
 
 
 L1BasicIterativeAttack.__call__.__doc__ = L1BasicIterativeAttack.as_generator.__doc__
+
+
+class SparseL1BasicIterativeAttack(
+        SparseL1GradientMixin,
+        L1ClippingMixin,
+        L1DistanceCheckMixin,
+        IterativeProjectedGradientBaseAttack):
+
+    """Sparse version of the Basic Iterative Method
+    that minimizes the L1 distance introduced in [1]_.
+
+     References
+    ----------
+    .. [1] Florian Tramèr, Dan Boneh,
+           "Adversarial Training and Robustness for Multiple Perturbations",
+           https://arxiv.org/abs/1904.13000
+
+    .. seealso:: :class:`L1BasicIterativeAttack`
+
+    """
+
+    @generator_decorator
+    def as_generator(self, a,
+                     q=0.80,
+                     binary_search=True,
+                     epsilon=0.3,
+                     stepsize=0.05,
+                     iterations=10,
+                     random_start=False,
+                     return_early=True):
+
+        """Sparse version of a gradient-based attack that minimizes the
+        L1 distance.
+
+        Parameters
+        ----------
+        inputs : `numpy.ndarray`
+            Batch of inputs with shape as expected by the underlying model.
+        labels : `numpy.ndarray`
+            Class labels of the inputs as a vector of integers in [0, number of classes).
+        unpack : bool
+            If true, returns the adversarial inputs as an array, otherwise returns Adversarial objects.
+        q: float
+            Relative percentile to make gradients sparse (must be in [0, 1])
+        binary_search : bool or int
+            Whether to perform a binary search over epsilon and stepsize,
+            keeping their ratio constant and using their values to start
+            the search. If False, hyperparameters are not optimized.
+            Can also be an integer, specifying the number of binary
+            search steps (default 20).
+        epsilon : float
+            Limit on the perturbation size; if binary_search is True,
+            this value is only for initialization and automatically
+            adapted.
+        stepsize : float
+            Step size for gradient descent; if binary_search is True,
+            this value is only for initialization and automatically
+            adapted.
+        iterations : int
+            Number of iterations for each gradient descent run.
+        random_start : bool
+            Start the attack from a random point rather than from the
+            original input.
+        return_early : bool
+            Whether an individual gradient descent run should stop as
+            soon as an adversarial is found.
+        """
+
+        assert epsilon > 0
+
+        yield from self._run(a, binary_search,
+                             epsilon, stepsize, iterations,
+                             random_start, return_early,
+                             gradient_kwargs={'q': q})
+
+
+SparseL1BasicIterativeAttack.__call__.__doc__ = SparseL1BasicIterativeAttack.as_generator.__doc__
 
 
 class L2BasicIterativeAttack(

--- a/foolbox/batch_attacks/iterative_projected_gradient.py
+++ b/foolbox/batch_attacks/iterative_projected_gradient.py
@@ -78,7 +78,7 @@ class IterativeProjectedGradientBaseAttack(BatchAttack):
             success = yield from self._run_one(
                 a, epsilon, optimizer, iterations,
                 random_start, targeted, class_, return_early)
-            
+
             return success
 
     def _run_binary_search(self, a, epsilon, stepsize, iterations,
@@ -94,7 +94,7 @@ class IterativeProjectedGradientBaseAttack(BatchAttack):
             success = yield from self._run_one(
                 a, epsilon, optimizer, iterations,
                 random_start, targeted, class_, return_early)
-         
+
             return success
 
         for i in range(k):

--- a/foolbox/batch_attacks/iterative_projected_gradient.py
+++ b/foolbox/batch_attacks/iterative_projected_gradient.py
@@ -201,9 +201,6 @@ class SparseL1GradientMixin(object):
 
         # using mean to make range of epsilons comparable to Linf
         normalization = np.mean(np.abs(e))
-        # make sure that we do not try to calculate 0/0
-        if normalization == 0:
-            normalization = 1
 
         gradient = e / normalization
         min_, max_ = a.bounds()
@@ -479,8 +476,8 @@ class SparseL1BasicIterativeAttack(
             Class labels of the inputs as a vector of integers in [0, number of classes).
         unpack : bool
             If true, returns the adversarial inputs as an array, otherwise returns Adversarial objects.
-        q: float
-            Relative percentile to make gradients sparse (must be in [0, 1])
+        q : float
+            Relative percentile to make gradients sparse (must be in [0, 1))
         binary_search : bool or int
             Whether to perform a binary search over epsilon and stepsize,
             keeping their ratio constant and using their values to start
@@ -506,6 +503,8 @@ class SparseL1BasicIterativeAttack(
         """
 
         assert epsilon > 0
+
+        assert 0.0 <= q < 1.0, '`q` must be in [0, 1).'
 
         yield from self._run(a, binary_search,
                              epsilon, stepsize, iterations,

--- a/foolbox/tests/batch_attacks/test_batch_iterative_projected_gradient.py
+++ b/foolbox/tests/batch_attacks/test_batch_iterative_projected_gradient.py
@@ -24,7 +24,7 @@ Attacks = [
     ProjectedGradientDescentAttack,
     RandomStartProjectedGradientDescentAttack,
     MomentumIterativeAttack,
-    SparseL1BasicIterativeAttack
+    SparseL1BasicIterativeAttack,
     AdamL1BasicIterativeAttack,
     AdamL2BasicIterativeAttack,
     AdamProjectedGradientDescentAttack,

--- a/foolbox/tests/batch_attacks/test_batch_iterative_projected_gradient.py
+++ b/foolbox/tests/batch_attacks/test_batch_iterative_projected_gradient.py
@@ -7,6 +7,7 @@ from foolbox.batch_attacks import L2BasicIterativeAttack
 from foolbox.batch_attacks import ProjectedGradientDescentAttack
 from foolbox.batch_attacks import RandomStartProjectedGradientDescentAttack
 from foolbox.batch_attacks import MomentumIterativeAttack
+from foolbox.batch_attacks import SparseL1BasicIterativeAttack
 
 from foolbox.distances import Linfinity
 from foolbox.distances import MAE
@@ -18,6 +19,7 @@ Attacks = [
     ProjectedGradientDescentAttack,
     RandomStartProjectedGradientDescentAttack,
     MomentumIterativeAttack,
+    SparseL1BasicIterativeAttack
 ]
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ filterwarnings =
     ignore:.*missing __init__.*:ImportWarning
     # produced by TensorFlow:
     ignore:.*can't resolve package from __spec__ or __package__.*:ImportWarning
+    # produced by TensorFlow/numpy:
     ignore::FutureWarning
 
 [build_sphinx]

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ filterwarnings =
     ignore:.*missing __init__.*:ImportWarning
     # produced by TensorFlow:
     ignore:.*can't resolve package from __spec__ or __package__.*:ImportWarning
+    ignore::FutureWarning
 
 [build_sphinx]
 warning-is-error = 1


### PR DESCRIPTION
Implementation of the attack described in [Adversarial Training and Robustness for Multiple Perturbations](https://arxiv.org/pdf/1904.13000.pdf)

For this, the existing code base of the iterative projected gradient descent has been extended so that parameters can be passed from the `as_generator()` method to the calculation of the gradients. This was necessary as the attack sparsifies the original L1 gradient depending on an attack parameter.