### PR TITLE
Add support for individual kwargs in run_sequential and run_parallel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
     - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then pip install -r requirements-dev-py3.txt; fi
     - travis_wait travis_retry pip install -r requirements-dev.txt
 
-    - travis_wait travis_retry pip install --upgrade tensorflow
+    - travis_wait travis_retry pip install --upgrade tensorflow==1.14
     - python -c 'import tensorflow; print(tensorflow.__version__)'
     - travis_wait travis_retry pip install --upgrade theano
     - python -c 'import theano; print(theano.__version__)'

--- a/foolbox/batch_attacks/base.py
+++ b/foolbox/batch_attacks/base.py
@@ -31,7 +31,8 @@ class BatchAttack(Attack):
 
         create_attack_fn = self.__class__
         advs = run_parallel(create_attack_fn, model, criterion, inputs, labels,
-                            distance=distance, threshold=threshold, **kwargs)
+                            distance=distance, threshold=threshold,
+                            attack_kwargs=kwargs)
 
         if unpack:
             advs = [a.perturbed for a in advs]

--- a/foolbox/tests/test_batching.py
+++ b/foolbox/tests/test_batching.py
@@ -23,6 +23,7 @@ def test_run_parallel_invalid_arguments(bn_model, bn_criterion, bn_images,
     labels_wrong = bn_labels[[0]]
     criteria_wrong = [bn_criterion] * (len(bn_images) + 1)
     distances_wrong = [MSE] * (len(bn_images) + 1)
+    attack_kwargs_wrong = [{'max_epsilon': 1}] * (len(bn_images) + 1)
 
     # test too few labels
     with pytest.raises(AssertionError):
@@ -38,6 +39,11 @@ def test_run_parallel_invalid_arguments(bn_model, bn_criterion, bn_images,
     with pytest.raises(AssertionError):
         run_parallel(Attack, bn_model, bn_criterion, bn_images,
                      bn_labels, distance=distances_wrong)
+
+    # test too many kwargs
+    with pytest.raises(AssertionError):
+        run_parallel(Attack, bn_model, bn_criterion, bn_images,
+                     bn_labels, attack_kwargs=attack_kwargs_wrong)
 
 
 def test_run_sequential(bn_model, bn_criterion, bn_images, bn_labels):
@@ -55,6 +61,7 @@ def test_run_sequential_invalid_arguments(bn_model, bn_criterion, bn_images,
     labels_wrong = bn_labels[[0]]
     criteria_wrong = [bn_criterion] * (len(bn_images) + 1)
     distances_wrong = [MSE] * (len(bn_images) + 1)
+    attack_kwargs_wrong = [{'max_epsilon': 1}] * (len(bn_images) + 1)
 
     # test too few labels
     with pytest.raises(AssertionError):
@@ -70,3 +77,8 @@ def test_run_sequential_invalid_arguments(bn_model, bn_criterion, bn_images,
     with pytest.raises(AssertionError):
         run_sequential(Attack, bn_model, bn_criterion, bn_images,
                        bn_labels, distance=distances_wrong)
+
+    # test too many kwargs
+    with pytest.raises(AssertionError):
+        run_sequential(Attack, bn_model, bn_criterion, bn_images,
+                       bn_labels, attack_kwargs=attack_kwargs_wrong)


### PR DESCRIPTION
This PR adds support for different kwargs per attack/input for `run_parallel` and `run_sequential` as proposed in [issue 349](https://github.com/bethgelab/foolbox/issues/349).