### PR TITLE
Use latest version of tf 1.x (1.15) for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
     - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then pip install -r requirements-dev-py3.txt; fi
     - travis_wait travis_retry pip install -r requirements-dev.txt
 
-    - travis_wait travis_retry pip install --upgrade tensorflow==1.13.2
+    - travis_wait travis_retry pip install --upgrade tensorflow==1.14
     - python -c 'import tensorflow; print(tensorflow.__version__)'
     - travis_wait travis_retry pip install --upgrade theano
     - python -c 'import theano; print(theano.__version__)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
     - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then pip install -r requirements-dev-py3.txt; fi
     - travis_wait travis_retry pip install -r requirements-dev.txt
 
-    - travis_wait travis_retry pip install --upgrade tensorflow==1.15
+    - travis_wait travis_retry pip install --upgrade tensorflow==1.13.2
     - python -c 'import tensorflow; print(tensorflow.__version__)'
     - travis_wait travis_retry pip install --upgrade theano
     - python -c 'import theano; print(theano.__version__)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
     - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then pip install -r requirements-dev-py3.txt; fi
     - travis_wait travis_retry pip install -r requirements-dev.txt
 
-    - travis_wait travis_retry pip install --upgrade tensorflow
+    - travis_wait travis_retry pip install --upgrade tensorflow==1.15
     - python -c 'import tensorflow; print(tensorflow.__version__)'
     - travis_wait travis_retry pip install --upgrade theano
     - python -c 'import theano; print(theano.__version__)'


### PR DESCRIPTION
Right now `foolbox` does not support `tensorflow==2.0` yet; therefore, the unit tests should also be run using the latest version of `tensorflow` 1.x.