### PR TITLE
Improve kwargs handling for batched attacks

### DIFF
--- a/foolbox/batch_attacks/base.py
+++ b/foolbox/batch_attacks/base.py
@@ -10,7 +10,7 @@ from ..batching import run_parallel
 
 
 class BatchAttack(Attack):
-    def __call__(self, inputs, labels, unpack=True, **kwargs):
+    def __call__(self, inputs, labels, unpack=True, individual_kwargs=None, **kwargs):
         assert isinstance(inputs, np.ndarray)
         assert isinstance(labels, np.ndarray)
 
@@ -32,7 +32,8 @@ class BatchAttack(Attack):
         create_attack_fn = self.__class__
         advs = run_parallel(create_attack_fn, model, criterion, inputs, labels,
                             distance=distance, threshold=threshold,
-                            attack_kwargs=kwargs)
+                            individual_kwargs=individual_kwargs,
+                            **kwargs)
 
         if unpack:
             advs = [a.perturbed for a in advs]

--- a/foolbox/batching.py
+++ b/foolbox/batching.py
@@ -45,6 +45,9 @@ def run_sequential(create_attack_fn, model, criterion, inputs, labels,
          The optional keywords passed to create_attack_fn that should be
          different for each of the input samples. For each input a different
          set of arguments will be used.
+    kwargs : dict
+        The optional keywords passed to create_attack_fn that are common for
+        every element in the batch.
 
     Returns
     -------
@@ -147,6 +150,9 @@ def run_parallel(create_attack_fn, model, criterion, inputs, labels,
          The optional keywords passed to create_attack_fn that should be
          different for each of the input samples. For each input a different
          set of arguments will be used.
+    kwargs : dict
+        The optional keywords passed to create_attack_fn that are common for
+        every element in the batch.
 
     Returns
     -------

--- a/foolbox/batching.py
+++ b/foolbox/batching.py
@@ -7,7 +7,7 @@ from .yielding_adversarial import YieldingAdversarial
 
 def run_sequential(create_attack_fn, model, criterion, inputs, labels,
                    distance=MSE, threshold=None, verbose=False,
-                   attack_kwargs=None):
+                   individual_kwargs=None, **kwargs):
     """
     Runs the same type of attack vor multiple inputs sequentially without
     batching them.
@@ -41,10 +41,10 @@ def run_sequential(create_attack_fn, model, criterion, inputs, labels,
         if the threshold has been reached.
     verbose : bool
         Whether the adversarial examples should be created in verbose mode.
-    attack_kwargs : dict or list of dict
-         The optional keywords passed to create_attack_fn. If a dict, the same
-         values will be used for all inputs; if a list, for each input a
-         different set of arguments will be used.
+    individual_kwargs : list of dict
+         The optional keywords passed to create_attack_fn that should be
+         different for each of the input samples. For each input a different
+         set of arguments will be used.
 
     Returns
     -------
@@ -65,14 +65,17 @@ def run_sequential(create_attack_fn, model, criterion, inputs, labels,
     else:
         assert len(distance) == len(inputs), 'The number of distances must match the number of inputs.'  # noqa: E501
 
-    if attack_kwargs is None:
-        attack_kwargs = {}
-
-    # if only one dict of kwargs has been passed use the same one for all inputs
-    if not isinstance(attack_kwargs, (list, tuple)):
-        attack_kwargs = [attack_kwargs] * len(inputs)
+    if individual_kwargs is None:
+        individual_kwargs = [kwargs] * len(inputs)
     else:
-        assert len(attack_kwargs) == len(inputs), 'The number of attack_kwargs must match the number of inputs.'  # noqa: E501
+        assert isinstance(individual_kwargs, (
+        list, tuple)), 'Individual_kwargs must be a list or None.'  # noqa: E501
+        assert len(individual_kwargs) == len(
+            inputs), 'The number of individual_kwargs must match the number of inputs.'  # noqa: E501
+
+        for i in range(len(individual_kwargs)):
+            assert isinstance(individual_kwargs[i], dict)
+            individual_kwargs[i] = {**kwargs, **individual_kwargs[i]}
 
     advs = [YieldingAdversarial(model, _criterion, x, label,
                                 distance=_distance, threshold=threshold,
@@ -80,7 +83,7 @@ def run_sequential(create_attack_fn, model, criterion, inputs, labels,
             for _criterion, _distance, x, label in zip(criterion, distance,
                                                        inputs, labels)]
     attacks = [create_attack_fn().as_generator(adv, **kwargs) for adv, kwargs
-               in zip(advs, attack_kwargs)]
+               in zip(advs, individual_kwargs)]
 
     supported_methods = {
         'forward_one': model.forward_one,
@@ -106,7 +109,7 @@ def run_sequential(create_attack_fn, model, criterion, inputs, labels,
 
 def run_parallel(create_attack_fn, model, criterion, inputs, labels,
                  distance=MSE, threshold=None, verbose=False,
-                 attack_kwargs=None):
+                 individual_kwargs=None, **kwargs):
     """
     Runs the same type of attack vor multiple inputs in parallel by
     batching them.
@@ -140,10 +143,10 @@ def run_parallel(create_attack_fn, model, criterion, inputs, labels,
         if the threshold has been reached.
     verbose : bool
         Whether the adversarial examples should be created in verbose mode.
-    attack_kwargs : dict or list of dict
-        The optional keywords passed to create_attack_fn. If a dict, the  same
-        values will be used for all inputs; if a list, for each input a
-        different set of arguments will be used.
+    individual_kwargs : list of dict
+         The optional keywords passed to create_attack_fn that should be
+         different for each of the input samples. For each input a different
+         set of arguments will be used.
 
     Returns
     -------
@@ -164,14 +167,18 @@ def run_parallel(create_attack_fn, model, criterion, inputs, labels,
     else:
         assert len(distance) == len(inputs), 'The number of distances must match the number of inputs.'  # noqa: E501
 
-    if attack_kwargs is None:
-        attack_kwargs = {}
-
-    # if only one dict of kwargs has been passed use the same one for all inputs
-    if not isinstance(attack_kwargs, (list, tuple)):
-        attack_kwargs = [attack_kwargs] * len(inputs)
+    if individual_kwargs is None:
+        individual_kwargs = [kwargs] * len(inputs)
     else:
-        assert len(attack_kwargs) == len(inputs), 'The number of attack_kwargs must match the number of inputs.'  # noqa: E501
+        assert isinstance(individual_kwargs, (
+            list,
+            tuple)), 'Individual_kwargs must be a list or None.'  # noqa: E501
+        assert len(individual_kwargs) == len(
+            inputs), 'The number of individual_kwargs must match the number of inputs.'  # noqa: E501
+
+        for i in range(len(individual_kwargs)):
+            assert isinstance(individual_kwargs[i], dict)
+            individual_kwargs[i] = {**kwargs, **individual_kwargs[i]}
 
     advs = [YieldingAdversarial(model, _criterion, x, label,
                                 distance=_distance, threshold=threshold,
@@ -179,7 +186,7 @@ def run_parallel(create_attack_fn, model, criterion, inputs, labels,
             for _criterion, _distance, x, label in zip(criterion, distance,
                                                        inputs, labels)]
     attacks = [create_attack_fn().as_generator(adv, **kwargs) for adv, kwargs
-               in zip(advs, attack_kwargs)]
+               in zip(advs, individual_kwargs)]
 
     predictions = [None for _ in attacks]
     gradients = []

--- a/foolbox/tests/test_batching.py
+++ b/foolbox/tests/test_batching.py
@@ -18,12 +18,67 @@ def test_run_parallel(bn_model, bn_criterion, bn_images, bn_labels):
     assert np.all(advs1 == advs2)
 
 
+def test_run_multiple_kwargs(bn_model, bn_criterion, bn_images, bn_labels):
+    attack = Attack(bn_model, bn_criterion)
+    advs1 = attack(bn_images, bn_labels, unpack=False,
+                   individual_kwargs=[{'epsilons': 900} for _ in bn_images])
+    advs1p = run_parallel(Attack, bn_model, bn_criterion, bn_images, bn_labels,
+                          individual_kwargs=[{'epsilons': 900} for _ in
+                                             bn_images])
+    advs1s = run_sequential(Attack, bn_model, bn_criterion, bn_images,
+                            bn_labels,
+                            individual_kwargs=[{'epsilons': 900} for _ in
+                                               bn_images])
+
+    advs2 = attack(bn_images, bn_labels, unpack=False,
+                   individual_kwargs=[{'epsilons': 900} for _ in bn_images],
+                   max_epsilon=0.99)
+    advs2p = run_parallel(Attack, bn_model, bn_criterion, bn_images, bn_labels,
+                          individual_kwargs=[{'epsilons': 900} for _ in
+                                             bn_images],
+                          max_epsilon=0.99)
+    advs2s = run_sequential(Attack, bn_model, bn_criterion, bn_images,
+                            bn_labels,
+                            individual_kwargs=[{'epsilons': 900} for _ in
+                                               bn_images],
+                            max_epsilon=0.99)
+
+    advs3 = attack(bn_images, bn_labels, unpack=False, max_epsilon=0.99)
+    advs3p = run_parallel(Attack, bn_model, bn_criterion, bn_images, bn_labels,
+                          max_epsilon=0.99)
+    advs3s = run_sequential(Attack, bn_model, bn_criterion, bn_images,
+                            bn_labels,
+                            max_epsilon=0.99)
+
+    for i in range(len(bn_images)):
+        assert advs1[i].perturbed is not None
+        assert advs2[i].perturbed is not None
+        assert advs3[i].perturbed is not None
+
+        assert advs1p[i].perturbed is not None
+        assert advs2p[i].perturbed is not None
+        assert advs3p[i].perturbed is not None
+
+        assert advs1s[i].perturbed is not None
+        assert advs2s[i].perturbed is not None
+        assert advs3s[i].perturbed is not None
+
+        assert np.allclose(advs1[i].perturbed, advs1p[i].perturbed)
+        assert np.allclose(advs1[i].perturbed, advs1s[i].perturbed)
+
+        assert np.allclose(advs2[i].perturbed, advs2p[i].perturbed)
+        assert np.allclose(advs2[i].perturbed, advs2s[i].perturbed)
+
+        assert np.allclose(advs3[i].perturbed, advs3p[i].perturbed)
+        assert np.allclose(advs3[i].perturbed, advs3s[i].perturbed)
+
+
 def test_run_parallel_invalid_arguments(bn_model, bn_criterion, bn_images,
                                         bn_labels):
     labels_wrong = bn_labels[[0]]
     criteria_wrong = [bn_criterion] * (len(bn_images) + 1)
     distances_wrong = [MSE] * (len(bn_images) + 1)
-    attack_kwargs_wrong = [{'max_epsilon': 1}] * (len(bn_images) + 1)
+    individual_kwargs_wrong = [{'max_epsilon': 1}] * (len(bn_images) + 1)
 
     # test too few labels
     with pytest.raises(AssertionError):
@@ -43,7 +98,7 @@ def test_run_parallel_invalid_arguments(bn_model, bn_criterion, bn_images,
     # test too many kwargs
     with pytest.raises(AssertionError):
         run_parallel(Attack, bn_model, bn_criterion, bn_images,
-                     bn_labels, attack_kwargs=attack_kwargs_wrong)
+                     bn_labels, individual_kwargs=individual_kwargs_wrong)
 
 
 def test_run_sequential(bn_model, bn_criterion, bn_images, bn_labels):
@@ -61,7 +116,7 @@ def test_run_sequential_invalid_arguments(bn_model, bn_criterion, bn_images,
     labels_wrong = bn_labels[[0]]
     criteria_wrong = [bn_criterion] * (len(bn_images) + 1)
     distances_wrong = [MSE] * (len(bn_images) + 1)
-    attack_kwargs_wrong = [{'max_epsilon': 1}] * (len(bn_images) + 1)
+    individual_kwargs_wrong = [{'max_epsilon': 1}] * (len(bn_images) + 1)
 
     # test too few labels
     with pytest.raises(AssertionError):
@@ -81,4 +136,4 @@ def test_run_sequential_invalid_arguments(bn_model, bn_criterion, bn_images,
     # test too many kwargs
     with pytest.raises(AssertionError):
         run_sequential(Attack, bn_model, bn_criterion, bn_images,
-                       bn_labels, attack_kwargs=attack_kwargs_wrong)
+                       bn_labels, individual_kwargs=individual_kwargs_wrong)


### PR DESCRIPTION
In [PR 362](https://github.com/bethgelab/foolbox/pull/362) we introduced support for different kwargs in the `run_parallel` and `run_sequential` method for the auto-batching. This PR aims to improve this implementation so that both individual and shared kwargs can be used. This means that existing API calls do not have to be changed but nevertheless one can use individual kwargs per image-label pair.