### PR TITLE
Add unit tests to check handling of invalid arguments

### DIFF
--- a/tests/test_attacks.py
+++ b/tests/test_attacks.py
@@ -1,13 +1,14 @@
-from typing import List, Tuple, Type
+from typing import List, Tuple, Type, TypeVar
 import pytest
 import eagerpy as ep
 
-import foolbox.ext.native as fbn
+import foolbox as fbn
 
 import re
 
 L2 = fbn.types.L2
 Linf = fbn.types.Linf
+
 
 attacks: List[Tuple[fbn.Attack, bool]] = [
     (fbn.attacks.DDNAttack(), True),
@@ -84,9 +85,9 @@ def test_targeted_attacks(
     assert adv_after_attack.sum().item() > adv_before_attack.sum().item()
 
 
-def test_ead_init_raises():
+def test_ead_init_raises() -> None:
     with pytest.raises(ValueError) as excinfo:
-        fbn.attacks.EADAttack(binary_search_steps=3, steps=20, decision_rule="L2")
+        fbn.attacks.EADAttack(binary_search_steps=3, steps=20, decision_rule="L2")  # type: ignore
 
     exception_text = str(excinfo.value)
     exception_text_found = (
@@ -95,7 +96,7 @@ def test_ead_init_raises():
     assert exception_text_found
 
 
-targeted_attacks_raises_exception: List[Tuple[Type[fbn.Attack], bool]] = [
+targeted_attacks_raises_exception: List[Tuple[fbn.Attack, bool]] = [
     (fbn.attacks.EADAttack(), True),
     (fbn.attacks.DDNAttack(), True),
     (fbn.attacks.L2CarliniWagnerAttack(), True),
@@ -135,7 +136,7 @@ def test_targeted_attacks_call_raises_exception(
         def __call__(
             self, perturbed: fbn.criteria.T, outputs: fbn.criteria.T
         ) -> fbn.criteria.T:
-            return ep.zeros(perturbed, len(perturbed)).double()
+            return perturbed
 
     invalid_criterion = DummyCriterion()
 

--- a/tests/test_attacks.py
+++ b/tests/test_attacks.py
@@ -1,8 +1,10 @@
-from typing import List, Tuple
+from typing import List, Tuple, Type
 import pytest
 import eagerpy as ep
 
-import foolbox as fbn
+import foolbox.ext.native as fbn
+
+import re
 
 L2 = fbn.types.L2
 Linf = fbn.types.Linf
@@ -80,3 +82,67 @@ def test_targeted_attacks(
     adv_before_attack = criterion(x, fmodel(x))
     adv_after_attack = criterion(advs, fmodel(advs))
     assert adv_after_attack.sum().item() > adv_before_attack.sum().item()
+
+
+def test_ead_init_raises():
+    with pytest.raises(ValueError) as excinfo:
+        fbn.attacks.EADAttack(binary_search_steps=3, steps=20, decision_rule="L2")
+
+    exception_text = str(excinfo.value)
+    exception_text_found = (
+        re.search("invalid decision rule", exception_text) is not None
+    )
+    assert exception_text_found
+
+
+targeted_attacks_raises_exception: List[Tuple[Type[fbn.Attack], bool]] = [
+    (fbn.attacks.EADAttack(), True),
+    (fbn.attacks.DDNAttack(), True),
+    (fbn.attacks.L2CarliniWagnerAttack(), True),
+]
+
+
+@pytest.mark.parametrize(
+    "attack_exception_text_and_grad", targeted_attacks_raises_exception
+)
+def test_targeted_attacks_call_raises_exception(
+    fmodel_and_data: Tuple[fbn.Model, ep.Tensor, ep.Tensor],
+    attack_exception_text_and_grad: Tuple[fbn.Attack, bool],
+) -> None:
+
+    attack, attack_uses_grad = attack_exception_text_and_grad
+    fmodel, x, y = fmodel_and_data
+
+    if isinstance(x, ep.NumPyTensor) and attack_uses_grad:
+        pytest.skip()
+
+    x = (x - fmodel.bounds.lower) / (fmodel.bounds.upper - fmodel.bounds.lower)
+    fmodel = fmodel.transform_bounds((0, 1))
+
+    num_classes = fmodel(x).shape[-1]
+    target_classes = (y + 1) % num_classes
+    invalid_target_classes = ep.concatenate((target_classes, target_classes), 0)
+    invalid_targeted_criterion = fbn.TargetedMisclassification(invalid_target_classes)
+
+    class DummyCriterion(fbn.Criterion):
+        """Criterion without any functionality which is just meant to be
+        rejected by the attacks
+        """
+
+        def __repr__(self) -> str:
+            return ""
+
+        def __call__(
+            self, perturbed: fbn.criteria.T, outputs: fbn.criteria.T
+        ) -> fbn.criteria.T:
+            return ep.zeros(perturbed, len(perturbed)).double()
+
+    invalid_criterion = DummyCriterion()
+
+    # check if targeted attack criterion with invalid number of classes is rejected
+    with pytest.raises(ValueError):
+        attack(fmodel, x, invalid_targeted_criterion)
+
+    # check if only the two valid criteria are accepted
+    with pytest.raises(ValueError):
+        attack(fmodel, x, invalid_criterion)

--- a/tests/test_attacks.py
+++ b/tests/test_attacks.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple, Type, TypeVar
+from typing import List, Tuple
 import pytest
 import eagerpy as ep
 

--- a/tests/test_attacks.py
+++ b/tests/test_attacks.py
@@ -4,8 +4,6 @@ import eagerpy as ep
 
 import foolbox as fbn
 
-import re
-
 L2 = fbn.types.L2
 Linf = fbn.types.Linf
 
@@ -83,67 +81,3 @@ def test_targeted_attacks(
     adv_before_attack = criterion(x, fmodel(x))
     adv_after_attack = criterion(advs, fmodel(advs))
     assert adv_after_attack.sum().item() > adv_before_attack.sum().item()
-
-
-def test_ead_init_raises() -> None:
-    with pytest.raises(ValueError) as excinfo:
-        fbn.attacks.EADAttack(binary_search_steps=3, steps=20, decision_rule="L2")  # type: ignore
-
-    exception_text = str(excinfo.value)
-    exception_text_found = (
-        re.search("invalid decision rule", exception_text) is not None
-    )
-    assert exception_text_found
-
-
-targeted_attacks_raises_exception: List[Tuple[fbn.Attack, bool]] = [
-    (fbn.attacks.EADAttack(), True),
-    (fbn.attacks.DDNAttack(), True),
-    (fbn.attacks.L2CarliniWagnerAttack(), True),
-]
-
-
-@pytest.mark.parametrize(
-    "attack_exception_text_and_grad", targeted_attacks_raises_exception
-)
-def test_targeted_attacks_call_raises_exception(
-    fmodel_and_data: Tuple[fbn.Model, ep.Tensor, ep.Tensor],
-    attack_exception_text_and_grad: Tuple[fbn.Attack, bool],
-) -> None:
-
-    attack, attack_uses_grad = attack_exception_text_and_grad
-    fmodel, x, y = fmodel_and_data
-
-    if isinstance(x, ep.NumPyTensor) and attack_uses_grad:
-        pytest.skip()
-
-    x = (x - fmodel.bounds.lower) / (fmodel.bounds.upper - fmodel.bounds.lower)
-    fmodel = fmodel.transform_bounds((0, 1))
-
-    num_classes = fmodel(x).shape[-1]
-    target_classes = (y + 1) % num_classes
-    invalid_target_classes = ep.concatenate((target_classes, target_classes), 0)
-    invalid_targeted_criterion = fbn.TargetedMisclassification(invalid_target_classes)
-
-    class DummyCriterion(fbn.Criterion):
-        """Criterion without any functionality which is just meant to be
-        rejected by the attacks
-        """
-
-        def __repr__(self) -> str:
-            return ""
-
-        def __call__(
-            self, perturbed: fbn.criteria.T, outputs: fbn.criteria.T
-        ) -> fbn.criteria.T:
-            return perturbed
-
-    invalid_criterion = DummyCriterion()
-
-    # check if targeted attack criterion with invalid number of classes is rejected
-    with pytest.raises(ValueError):
-        attack(fmodel, x, invalid_targeted_criterion)
-
-    # check if only the two valid criteria are accepted
-    with pytest.raises(ValueError):
-        attack(fmodel, x, invalid_criterion)

--- a/tests/test_attacks_raise.py
+++ b/tests/test_attacks_raise.py
@@ -1,0 +1,66 @@
+from typing import List, Tuple
+import pytest
+import eagerpy as ep
+
+import foolbox as fbn
+
+L2 = fbn.types.L2
+Linf = fbn.types.Linf
+
+
+def test_ead_init_raises() -> None:
+    with pytest.raises(ValueError, match="invalid decision rule"):
+        fbn.attacks.EADAttack(binary_search_steps=3, steps=20, decision_rule="L2")  # type: ignore
+
+
+targeted_attacks_raises_exception: List[Tuple[fbn.Attack, bool]] = [
+    (fbn.attacks.EADAttack(), True),
+    (fbn.attacks.DDNAttack(), True),
+    (fbn.attacks.L2CarliniWagnerAttack(), True),
+]
+
+
+@pytest.mark.parametrize(
+    "attack_exception_text_and_grad", targeted_attacks_raises_exception
+)
+def test_targeted_attacks_call_raises_exception(
+    fmodel_and_data: Tuple[fbn.Model, ep.Tensor, ep.Tensor],
+    attack_exception_text_and_grad: Tuple[fbn.Attack, bool],
+) -> None:
+
+    attack, attack_uses_grad = attack_exception_text_and_grad
+    fmodel, x, y = fmodel_and_data
+
+    if isinstance(x, ep.NumPyTensor) and attack_uses_grad:
+        pytest.skip()
+
+    x = (x - fmodel.bounds.lower) / (fmodel.bounds.upper - fmodel.bounds.lower)
+    fmodel = fmodel.transform_bounds((0, 1))
+
+    num_classes = fmodel(x).shape[-1]
+    target_classes = (y + 1) % num_classes
+    invalid_target_classes = ep.concatenate((target_classes, target_classes), 0)
+    invalid_targeted_criterion = fbn.TargetedMisclassification(invalid_target_classes)
+
+    class DummyCriterion(fbn.Criterion):
+        """Criterion without any functionality which is just meant to be
+        rejected by the attacks
+        """
+
+        def __repr__(self) -> str:
+            return ""
+
+        def __call__(
+            self, perturbed: fbn.criteria.T, outputs: fbn.criteria.T
+        ) -> fbn.criteria.T:
+            return perturbed
+
+    invalid_criterion = DummyCriterion()
+
+    # check if targeted attack criterion with invalid number of classes is rejected
+    with pytest.raises(ValueError):
+        attack(fmodel, x, invalid_targeted_criterion)
+
+    # check if only the two valid criteria are accepted
+    with pytest.raises(ValueError):
+        attack(fmodel, x, invalid_criterion)


### PR DESCRIPTION
This PR adds two types of unit tests: one for checking if incorrect arguments during the attack's initialization are correctly rejected and one for doing the same in the attack's `__call__` function.