### PR TITLE
Pass data_format through TransformBoundsWrapper

### DIFF
--- a/foolbox/models/base.py
+++ b/foolbox/models/base.py
@@ -64,6 +64,10 @@ class TransformBoundsWrapper(Model):
         min_, max_ = self._model.bounds
         return x * (max_ - min_) + min_
 
+    @property
+    def data_format(self) -> str:
+        return getattr(self._model, "data_format", None)
+
 
 ModelType = TypeVar("ModelType", bound="ModelWithPreprocessing")
 

--- a/foolbox/models/base.py
+++ b/foolbox/models/base.py
@@ -65,7 +65,7 @@ class TransformBoundsWrapper(Model):
         return x * (max_ - min_) + min_
 
     @property
-    def data_format(self) -> str:
+    def data_format(self) -> Any:
         return getattr(self._model, "data_format", None)
 
 

--- a/tests/test_attacks_base.py
+++ b/tests/test_attacks_base.py
@@ -48,9 +48,18 @@ def test_get_channel_axis() -> None:
 
 
 def test_transform_bounds_wrapper_data_format() -> None:
-    class Model:
+    class Model(fbn.models.Model):
         data_format = "channels_first"
+
+        @property
+        def bounds(self) -> fbn.types.Bounds:
+            return fbn.types.Bounds(0, 1)
+
+        def __call__(self, inputs: fbn.models.base.T) -> fbn.models.base.T:
+            return inputs
 
     model = Model()
     wrapped_model = fbn.models.TransformBoundsWrapper(model, (0, 1))
-    assert fbn.attacks.base.get_channel_axis(model, 3) == fbn.attacks.base.get_channel_axis(wrapped_model, 3)  # type: ignore
+    assert fbn.attacks.base.get_channel_axis(
+        model, 3
+    ) == fbn.attacks.base.get_channel_axis(wrapped_model, 3)

--- a/tests/test_attacks_base.py
+++ b/tests/test_attacks_base.py
@@ -45,3 +45,12 @@ def test_get_channel_axis() -> None:
     model.data_format = "invalid"  # type: ignore
     with pytest.raises(ValueError):
         assert fbn.attacks.base.get_channel_axis(model, 3)  # type: ignore
+
+
+def test_transform_bounds_wrapper_data_format() -> None:
+    class Model:
+        data_format = "channels_first"
+
+    model = Model()
+    wrapped_model = fbn.models.TransformBoundsWrapper(model, (0, 1))
+    assert fbn.attacks.base.get_channel_axis(model, 3) == fbn.attacks.base.get_channel_axis(wrapped_model, 3)  # type: ignore


### PR DESCRIPTION
Currently, by wrapping a model with the `TransformBoundsWrapper` class, one loses information about the data format used in the model. That causes problems in attacks which need to infer the channel axis.
This PR extends the `TransformBoundsWrapper` class by adding the `data_format` property to it, which just returns the value of the `data_format` of the inner model.