### PR TITLE
Numbawarning

### DIFF
--- a/foolbox/attacks/brendel_bethge.py
+++ b/foolbox/attacks/brendel_bethge.py
@@ -23,7 +23,7 @@ from ..distances import l0, l1, l2, linf
 
 try:
     from numba import jitclass  # type: ignore
-    import numba  # type: ignore
+    import numba
 except (ModuleNotFoundError, ImportError) as e:  # pragma: no cover
     # delay the error until the attack is initialized
     NUMBA_IMPORT_ERROR = e

--- a/foolbox/attacks/brendel_bethge.py
+++ b/foolbox/attacks/brendel_bethge.py
@@ -356,8 +356,10 @@ class BrendelBethgeAttack(MinimizationAttack, ABC):
         if NUMBA_IMPORT_ERROR is not None:
             raise NUMBA_IMPORT_ERROR  # pragma: no cover
 
-        if '0.49.' in numba.__version__:
-            warnings.warn('There are known issues with numba version 0.49 and we suggest using numba 0.50 or newer.')
+        if "0.49." in numba.__version__:
+            warnings.warn(
+                "There are known issues with numba version 0.49 and we suggest using numba 0.50 or newer."
+            )
 
         self.init_attack = init_attack
         self.overshoot = overshoot

--- a/foolbox/attacks/brendel_bethge.py
+++ b/foolbox/attacks/brendel_bethge.py
@@ -23,6 +23,7 @@ from ..distances import l0, l1, l2, linf
 
 try:
     from numba import jitclass  # type: ignore
+    import numba  # type: ignore
 except (ModuleNotFoundError, ImportError) as e:  # pragma: no cover
     # delay the error until the attack is initialized
     NUMBA_IMPORT_ERROR = e
@@ -36,7 +37,6 @@ except (ModuleNotFoundError, ImportError) as e:  # pragma: no cover
 
 else:
     NUMBA_IMPORT_ERROR = None
-
 
 EPS = 1e-10
 
@@ -355,6 +355,9 @@ class BrendelBethgeAttack(MinimizationAttack, ABC):
 
         if NUMBA_IMPORT_ERROR is not None:
             raise NUMBA_IMPORT_ERROR  # pragma: no cover
+        
+        if '0.49.' in numba.__version__:
+            warnings.warn('There are known issues with numba version 0.49 and we suggest using numba 0.50 or newer.')
 
         self.init_attack = init_attack
         self.overshoot = overshoot

--- a/foolbox/attacks/brendel_bethge.py
+++ b/foolbox/attacks/brendel_bethge.py
@@ -355,7 +355,7 @@ class BrendelBethgeAttack(MinimizationAttack, ABC):
 
         if NUMBA_IMPORT_ERROR is not None:
             raise NUMBA_IMPORT_ERROR  # pragma: no cover
-        
+
         if '0.49.' in numba.__version__:
             warnings.warn('There are known issues with numba version 0.49 and we suggest using numba 0.50 or newer.')
 

--- a/foolbox/attacks/spatial_attack_transformations.py
+++ b/foolbox/attacks/spatial_attack_transformations.py
@@ -62,7 +62,7 @@ def transform_pt(
     new_coords = new_coords.squeeze_(-1)
 
     # align_corners=True to match tf implementation
-    transformed_images = torch.nn.functional.grid_sample(
+    transformed_images = torch.nn.functional.grid_sample(  # type: ignore
         x, new_coords, mode="bilinear", padding_mode="zeros", align_corners=True
     )
     return astensor(transformed_images)

--- a/foolbox/attacks/spatial_attack_transformations.py
+++ b/foolbox/attacks/spatial_attack_transformations.py
@@ -62,7 +62,7 @@ def transform_pt(
     new_coords = new_coords.squeeze_(-1)
 
     # align_corners=True to match tf implementation
-    transformed_images = torch.nn.functional.grid_sample(  # type: ignore
+    transformed_images = torch.nn.functional.grid_sample(
         x, new_coords, mode="bilinear", padding_mode="zeros", align_corners=True
     )
     return astensor(transformed_images)


### PR DESCRIPTION
Numba version 0.49 breaks compilation of Brendel & Bethge code, but later versions are ok. Added warning.