### PR TITLE
Fix interrupted network connection during pip install

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,14 +54,14 @@ jobs:
     - name: Install requirements.txt
       run: |
         function retry-with-backoff() {
-                    for BACKOFF in 0 1 2 4 8 16 32 64; do
-                        sleep $BACKOFF
-                        if "$@"; then
-                            return 0
-                        fi
-                    done
-                    return 1
-                }
+          for BACKOFF in 0 1 2 4 8 16 32 64; do
+            sleep $BACKOFF
+            if "$@"; then
+              return 0
+            fi
+          done
+          return 1
+        }
 
         python -m pip install --upgrade pip setuptools
         retry-with-backoff pip install -r requirements.txt
@@ -77,15 +77,15 @@ jobs:
     - name: Install tests/requirements.txt
       run: |
         function retry-with-backoff() {
-                            for BACKOFF in 0 1 2 4 8 16 32 64; do
-                                sleep $BACKOFF
-                                if "$@"; then
-                                    return 0
-                                fi
-                            done
-                            return 1
-                        }
-        
+          for BACKOFF in 0 1 2 4 8 16 32 64; do
+            sleep $BACKOFF
+            if "$@"; then
+              return 0
+            fi
+          done
+          return 1
+        }
+
         retry-with-backoff pip install -r tests/requirements.txt
     - name: mypy (package)
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,7 +62,7 @@ jobs:
                     done
                     return 1
                 }
-        
+
         python -m pip install --upgrade pip setuptools
         retry-with-backoff pip install -r requirements.txt
     - name: flake8
@@ -76,6 +76,16 @@ jobs:
         pip install -e .
     - name: Install tests/requirements.txt
       run: |
+        function retry-with-backoff() {
+                            for BACKOFF in 0 1 2 4 8 16 32 64; do
+                                sleep $BACKOFF
+                                if "$@"; then
+                                    return 0
+                                fi
+                            done
+                            return 1
+                        }
+        
         retry-with-backoff pip install -r tests/requirements.txt
     - name: mypy (package)
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,8 +53,18 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install requirements.txt
       run: |
+        function retry-with-backoff() {
+                    for BACKOFF in 0 1 2 4 8 16 32 64; do
+                        sleep $BACKOFF
+                        if "$@"; then
+                            return 0
+                        fi
+                    done
+                    return 1
+                }
+        
         python -m pip install --upgrade pip setuptools
-        pip install -r requirements.txt
+        retry-with-backoff pip install -r requirements.txt
     - name: flake8
       run: |
         flake8 . --count --show-source --statistics
@@ -66,7 +76,7 @@ jobs:
         pip install -e .
     - name: Install tests/requirements.txt
       run: |
-        pip install -r tests/requirements.txt
+        retry-with-backoff pip install -r tests/requirements.txt
     - name: mypy (package)
       run: |
         mypy -p foolbox


### PR DESCRIPTION
Retry to install packages multiple times upon failure due to an interrupted network connected as suggested by [AveshCSingh](https://github.com/mlflow/mlflow/pull/3236).