### PR TITLE
Implement HopSkipJump attack

### DIFF
--- a/foolbox/attacks/__init__.py
+++ b/foolbox/attacks/__init__.py
@@ -46,6 +46,7 @@ from .blended_noise import LinearSearchBlendedUniformNoiseAttack  # noqa: F401
 from .binarization import BinarizationRefinementAttack  # noqa: F401
 from .dataset_attack import DatasetAttack  # noqa: F401
 from .boundary_attack import BoundaryAttack  # noqa: F401
+from .hop_skip_jump import HopSkipJump  # noqa: F401
 from .brendel_bethge import (  # noqa: F401
     L0BrendelBethgeAttack,
     L1BrendelBethgeAttack,

--- a/foolbox/attacks/hop_skip_jump.py
+++ b/foolbox/attacks/hop_skip_jump.py
@@ -329,18 +329,23 @@ class HopSkipJump(MinimizationAttack):
             thresholds = self.gamma / (d * math.sqrt(d))
 
         lows = np.zeros_like(highs)
+        # keep also a float representation of the high values to return them later
+        highs_fl = highs.astype(np.float32)
 
         while np.any(highs - lows > thresholds):
             mids = (lows + highs) / 2
+            mids_fl = mids.astype(np.float32)
             mids_perturbed = self._project(
-                originals, perturbed, ep.from_numpy(originals, mids.astype(np.float32))
+                originals, perturbed, ep.from_numpy(originals, mids_fl)
             )
             is_adversarial_ = is_adversarial(mids_perturbed)
 
             highs = np.where(is_adversarial_, mids, highs)
             lows = np.where(is_adversarial_, lows, mids)
 
-        return self._project(originals, perturbed, ep.from_numpy(originals, highs))
+            highs_fl = np.where(is_adversarial_, mids_fl, highs_fl)
+
+        return self._project(originals, perturbed, ep.from_numpy(originals, highs_fl))
 
     def select_delta(
         self, originals: ep.Tensor, distances: ep.Tensor, step: int

--- a/foolbox/attacks/hop_skip_jump.py
+++ b/foolbox/attacks/hop_skip_jump.py
@@ -329,7 +329,6 @@ class HopSkipJump(MinimizationAttack):
 
         lows = np.zeros_like(highs)
 
-        k = 0
         while np.any(highs - lows > thresholds):
             mids = (lows + highs) / 2
             mids_perturbed = self._project(
@@ -339,13 +338,6 @@ class HopSkipJump(MinimizationAttack):
 
             highs = np.where(is_adversarial_, mids, highs)
             lows = np.where(is_adversarial_, lows, mids)
-
-            k += 1
-
-            if k % 50 == 0:
-                import pdb
-
-                pdb.set_trace()
 
         return self._project(originals, perturbed, ep.from_numpy(originals, highs))
 

--- a/foolbox/attacks/hop_skip_jump.py
+++ b/foolbox/attacks/hop_skip_jump.py
@@ -1,0 +1,309 @@
+import logging
+from typing import Union, Any, Optional
+from typing_extensions import Literal
+
+import math
+
+import eagerpy as ep
+import numpy as np
+
+from foolbox.attacks import LinearSearchBlendedUniformNoiseAttack
+from foolbox.tensorboard import TensorBoard
+from ..models import Model
+
+from ..criteria import Criterion
+
+from ..distances import l1
+
+from ..devutils import atleast_kd, flatten
+
+from .base import MinimizationAttack, get_is_adversarial
+from .base import get_criterion
+from .base import T
+from .base import raise_if_kwargs
+from ..distances import l2, linf
+
+
+class HopSkipJump(MinimizationAttack):
+    """A powerful adversarial attack that requires neither gradients
+    nor probabilities [#Chen19].
+
+    Args:
+        binary_search_steps : Number of steps to perform in the binary search
+            over the const c.
+        steps : Number of optimization steps within each binary search step.
+        initial_stepsize : Initial stepsize to update the examples.
+        confidence : Confidence required for an example to be marked as adversarial.
+            Controls the gap between example and decision boundary.
+        initial_const : Initial value of the const c with which the binary search starts.
+        regularization : Controls the L1 regularization.
+        decision_rule : Rule according to which the best adversarial examples are selected.
+            They either minimize the L1 or ElasticNet distance.
+        abort_early : Stop inner search as soons as an adversarial example has been found.
+            Does not affect the binary search over the const c.
+
+    References:
+        .. [#Chen19] Jianbo Chen, Michael I. Jordan, Martin J. Wainwright,
+        "HopSkipJumpAttack: A Query-Efficient Decision-Based Attack",
+        https://arxiv.org/abs/1904.02144
+    """
+
+    distance = l1
+
+    def __init__(
+        self,
+        init_attack: Optional[MinimizationAttack] = None,
+        steps: int = 64,
+        initial_num_evals: int = 100,
+        max_num_evals: int = 10000,
+        stepsize_search: Union[
+            Literal["geometric_progression"], Literal["grid_search"]
+        ] = "geometric_progression",
+        gamma: float = 1.0,
+        tensorboard: Union[Literal[False], None, str] = False,
+        constraint: Union[Literal["linf"], Literal["l2"]] = "l2",
+    ):
+        if init_attack is not None and not isinstance(init_attack, MinimizationAttack):
+            raise NotImplementedError
+        self.init_attack = init_attack
+        self.steps = steps
+        self.initial_num_evals = initial_num_evals
+        self.max_num_evals = max_num_evals
+        self.stepsize_search = stepsize_search
+        self.gamma = gamma
+        self.tensorboard = tensorboard
+        self.constraint = constraint
+
+        assert constraint in ("l2", "linf")
+        if constraint == "l2":
+            self.distance = l2
+        else:
+            self.distance = "linf"
+
+    def run(
+        self,
+        model: Model,
+        inputs: T,
+        criterion: Union[Criterion, T],
+        *,
+        early_stop: Optional[float] = None,
+        starting_points: Optional[T] = None,
+        **kwargs: Any,
+    ) -> T:
+        raise_if_kwargs(kwargs)
+        originals, restore_type = ep.astensor_(inputs)
+        del inputs, kwargs
+
+        criterion = get_criterion(criterion)
+        is_adversarial = get_is_adversarial(criterion, model)
+
+        if starting_points is None:
+            init_attack: MinimizationAttack
+            if self.init_attack is None:
+                init_attack = LinearSearchBlendedUniformNoiseAttack(steps=50)
+                logging.info(
+                    f"Neither starting_points nor init_attack given. Falling"
+                    f" back to {init_attack!r} for initialization."
+                )
+            else:
+                init_attack = self.init_attack
+            # TODO: use call and support all types of attacks (once early_stop is
+            # possible in __call__)
+            x_advs = init_attack.run(model, originals, criterion, early_stop=early_stop)
+        else:
+            x_advs = ep.astensor(starting_points)
+
+        is_adv = is_adversarial(x_advs)
+        if not is_adv.all():
+            failed = is_adv.logical_not().float32().sum()
+            if starting_points is None:
+                raise ValueError(
+                    f"init_attack failed for {failed} of {len(is_adv)} inputs"
+                )
+            else:
+                raise ValueError(
+                    f"{failed} of {len(is_adv)} starting_points are not adversarial"
+                )
+        del starting_points
+
+        tb = TensorBoard(logdir=self.tensorboard)
+
+        # Project the initialization to the boundary.
+        x_advs = self._binary_search(is_adversarial, originals, x_advs)
+
+        distances = self.distance(originals, x_advs)
+
+        for step in range(self.steps):
+            delta = self.select_delta(originals, distances, step)
+
+            # Choose number of gradient estimation steps.
+            num_gradient_estimation_steps = int(
+                min([self.initial_num_evals * math.sqrt(step + 1), self.max_num_evals])
+            )
+
+            gradients = self.approximate_gradients(
+                is_adversarial, x_advs, num_gradient_estimation_steps, delta
+            )
+
+            if self.constraint == "linf":
+                update = ep.sign(gradients)
+            else:
+                update = gradients
+
+            if self.stepsize_search == "geometric_progression":
+                # find step size.
+                epsilons = distances / math.sqrt(step + 1)
+                while True:
+                    x_advs_proposals = ep.clip(
+                        x_advs + atleast_kd(epsilons, x_advs.ndim) * update, 0, 1
+                    )
+                    success = is_adversarial(x_advs_proposals)
+                    epsilons = ep.where(success, epsilons, epsilons / 2.0)
+
+                    if ep.all(success):
+                        break
+
+                # Update the sample.
+                x_advs = ep.clip(
+                    x_advs + atleast_kd(epsilons, update.ndim) * update, 0, 1
+                )
+
+                # Binary search to return to the boundary.
+                x_advs = self._binary_search(is_adversarial, originals, x_advs)
+
+            elif self.stepsize_search == "grid_search":
+                # Grid search for stepsize.
+                epsilons_grid = ep.logspace(-4, 0, num=20, endpoint=True) * distances
+
+                proposals_list = []
+
+                for epsilons in epsilons_grid:
+                    x_advs_proposals = x_advs + epsilons * update
+                    x_advs_proposals = ep.clip(x_advs_proposals, 0, 1)
+
+                    mask = is_adversarial(x_advs_proposals)
+
+                    x_advs_proposals = self._binary_search(
+                        is_adversarial, originals, x_advs_proposals
+                    )
+
+                    # only use new values where initial guess was already adversarial
+                    x_advs_proposals = ep.where(mask, x_advs_proposals, x_advs)
+
+                    proposals_list.append(x_advs_proposals)
+
+                proposals = ep.stack(proposals_list, 0)
+                proposals_distances = self.distance(
+                    ep.expand_dims(originals, 0), proposals
+                )
+                minimal_idx = ep.argmin(proposals_distances, 0)
+
+                x_advs = proposals[minimal_idx]
+
+                # log stats
+                tb.histogram("norms", distances, step)
+
+            distances = self.distance(originals, x_advs)
+
+        return restore_type(x_advs)
+
+    def approximate_gradients(self, is_adversarial, x_advs, steps, delta):
+        # (steps, bs, ...)
+        noise_shape = [steps] + list(x_advs.shape)
+        if self.constraint == "l2":
+            rv = ep.normal(x_advs, noise_shape)
+        elif self.constraint == "linf":
+            rv = ep.uniform(x_advs, low=-1, high=1, shape=noise_shape)
+        rv /= atleast_kd(ep.norms.l2(flatten(rv, keep=2), -1), rv.ndim)
+
+        scaled_rv = atleast_kd(ep.expand_dims(delta, 0), rv.ndim) * rv
+
+        perturbed = ep.expand_dims(x_advs, 0) + scaled_rv
+        perturbed = ep.clip(perturbed, 0, 1)
+
+        rv = (perturbed - x_advs) / 2
+
+        multipliers = []
+        for step in range(steps):
+            decision = is_adversarial(perturbed[step])
+            multipliers.append(
+                ep.where(
+                    decision,
+                    ep.ones(x_advs, (len(x_advs,))),
+                    -ep.ones(x_advs, (len(decision,))),
+                )
+            )
+        # (steps, bs, ...)
+        multipliers = ep.stack(multipliers, 0)
+
+        vals = ep.where(
+            ep.abs(ep.mean(multipliers, axis=0, keepdims=True)) == 1,
+            multipliers,
+            multipliers - ep.mean(multipliers, axis=0, keepdims=True),
+        )
+        grad = ep.mean(atleast_kd(vals, rv.ndim) * rv, axis=0)
+
+        grad /= ep.norms.l2(atleast_kd(flatten(grad), grad.ndim))
+
+        return grad
+
+    def _project(self, originals: T, perturbed: T, epsilon):
+        """Clips the perturbations to epsilon and returns the new perturbed
+
+        Args:
+            originals: A batch of reference inputs.
+            perturbed: A batch of perturbed inputs.
+
+        Returns:
+            A tensor like perturbed but with the perturbation clipped to epsilon.
+        """
+
+        (x, y), restore_type = ep.astensors_(originals, perturbed)
+        p = y - x
+        if self.distance == ep.inf:
+            clipped_perturbation = ep.clip(p, -epsilon, epsilon)
+            return restore_type(x + clipped_perturbation)
+        else:
+            norms = ep.norms.lp(flatten(p), 2, axis=-1)
+            norms = ep.maximum(norms, 1e-12)  # avoid division by zero
+            factor = epsilon / norms
+
+            factor = atleast_kd(factor, x.ndim)
+            clipped_perturbation = factor * p
+            return restore_type(x + clipped_perturbation)
+
+    def _binary_search(self, is_adversarial, originals, perturbed):
+        # Choose upper thresholds in binary search is based on constraint.
+        d = np.prod(perturbed.shape[1:])
+        if self.constraint == "linf":
+            highs = linf(originals, perturbed)
+            # Stopping criteria.
+            # TODO: Check if the threshold is correct
+            thresholds = highs * self.gamma / (d * d)
+        else:
+            highs = ep.ones(perturbed, len(perturbed)) * math.sqrt(d)
+            # TODO: Check if the threshold is correct
+            thresholds = self.gamma / math.sqrt(d)
+
+        lows = ep.zeros_like(highs)
+
+        while ep.all(highs - lows > thresholds):
+            mids = (lows + highs) / 2
+            mids_perturbed = self._project(originals, perturbed, mids)
+            is_adversarial_ = is_adversarial(mids_perturbed)
+
+            highs = ep.where(is_adversarial_, mids, highs)
+            lows = ep.where(is_adversarial_, lows, mids)
+
+        return self._project(originals, perturbed, highs)
+
+    def select_delta(self, originals, distances, step):
+        if step == 0:
+            return 0.1 * ep.ones_like(distances)
+        else:
+            d = np.prod(originals.shape[1:])
+            theta = self.gamma / (d * d)
+            if self.constraint == "linf":
+                return ep.sqrt(d) * theta * distances
+            else:
+                return d * theta * distances

--- a/foolbox/attacks/hop_skip_jump.py
+++ b/foolbox/attacks/hop_skip_jump.py
@@ -230,7 +230,7 @@ class HopSkipJump(MinimizationAttack):
             rv = ep.normal(x_advs, noise_shape)
         elif self.constraint == "linf":
             rv = ep.uniform(x_advs, low=-1, high=1, shape=noise_shape)
-        rv /= atleast_kd(ep.norms.l2(flatten(rv, keep=2), -1), rv.ndim)
+        rv /= atleast_kd(ep.norms.l2(flatten(rv, keep=1), -1), rv.ndim)
 
         scaled_rv = atleast_kd(ep.expand_dims(delta, 0), rv.ndim) * rv
 
@@ -307,7 +307,6 @@ class HopSkipJump(MinimizationAttack):
             thresholds = highs * self.gamma / (d * d)
         else:
             highs = ep.ones(perturbed, len(perturbed)) * math.sqrt(d)
-            # TODO: Check if the threshold is correct
             thresholds = self.gamma / math.sqrt(d)
 
         lows = ep.zeros_like(highs)

--- a/foolbox/attacks/hop_skip_jump.py
+++ b/foolbox/attacks/hop_skip_jump.py
@@ -320,7 +320,6 @@ class HopSkipJump(MinimizationAttack):
         d = np.prod(perturbed.shape[1:])
         if self.constraint == "linf":
             highs = linf(originals, perturbed).numpy().astype(np.float64)
-
             # TODO: Check if the threshold is correct
             #  empirically this seems to be too low
             thresholds = highs * self.gamma / (d * d)

--- a/foolbox/attacks/hop_skip_jump.py
+++ b/foolbox/attacks/hop_skip_jump.py
@@ -325,7 +325,7 @@ class HopSkipJump(MinimizationAttack):
             #  empirically this seems to be too low
             thresholds = highs * self.gamma / (d * d)
         else:
-            highs = np.ones(len(perturbed), dtype=np.float54)
+            highs = np.ones(len(perturbed), dtype=np.float64)
             thresholds = self.gamma / (d * math.sqrt(d))
 
         lows = np.zeros_like(highs)

--- a/tests/test_hsj_attack.py
+++ b/tests/test_hsj_attack.py
@@ -15,7 +15,7 @@ def get_attack_id(x: Tuple[BrendelBethgeAttack, Union[int, float]]) -> str:
 attacks: List[Tuple[fa.Attack, Union[int, float]]] = [
     (
         fa.HopSkipJump(
-            steps=2,
+            steps=1,
             constraint="linf",
             initial_gradient_eval_steps=100,
             max_gradient_eval_steps=100,
@@ -24,7 +24,7 @@ attacks: List[Tuple[fa.Attack, Union[int, float]]] = [
     ),
     (
         fa.HopSkipJump(
-            steps=2,
+            steps=1,
             constraint="l2",
             initial_gradient_eval_steps=100,
             max_gradient_eval_steps=100,
@@ -33,7 +33,7 @@ attacks: List[Tuple[fa.Attack, Union[int, float]]] = [
     ),
     (
         fa.HopSkipJump(
-            steps=2,
+            steps=1,
             constraint="l2",
             initial_gradient_eval_steps=100,
             max_gradient_eval_steps=100,

--- a/tests/test_hsj_attack.py
+++ b/tests/test_hsj_attack.py
@@ -15,11 +15,16 @@ def get_attack_id(x: Tuple[BrendelBethgeAttack, Union[int, float]]) -> str:
 attacks: List[Tuple[fa.Attack, Union[int, float]]] = [
     (
         fa.HopSkipJump(
-            steps=3, constraint="linf", gamma=1e6, max_gradient_eval_steps=250
+            steps=3, constraint="linf", gamma=1e7, initial_gradient_eval_steps=50
         ),
         ep.inf,
     ),
-    (fa.HopSkipJump(steps=3, constraint="l2", max_gradient_eval_steps=250), 2),
+    (
+        fa.HopSkipJump(
+            steps=3, constraint="l2", initial_gradient_eval_steps=50, gamma=1e3
+        ),
+        2,
+    ),
 ]
 
 

--- a/tests/test_hsj_attack.py
+++ b/tests/test_hsj_attack.py
@@ -13,8 +13,13 @@ def get_attack_id(x: Tuple[BrendelBethgeAttack, Union[int, float]]) -> str:
 
 
 attacks: List[Tuple[fa.Attack, Union[int, float]]] = [
-    (fa.HopSkipJump(steps=3, constraint="linf", gamma=1e6), ep.inf),
-    (fa.HopSkipJump(steps=3, constraint="l2"), 2),
+    (
+        fa.HopSkipJump(
+            steps=3, constraint="linf", gamma=1e6, max_gradient_eval_steps=250
+        ),
+        ep.inf,
+    ),
+    (fa.HopSkipJump(steps=3, constraint="l2", max_gradient_eval_steps=250), 2),
 ]
 
 

--- a/tests/test_hsj_attack.py
+++ b/tests/test_hsj_attack.py
@@ -15,13 +15,19 @@ def get_attack_id(x: Tuple[BrendelBethgeAttack, Union[int, float]]) -> str:
 attacks: List[Tuple[fa.Attack, Union[int, float]]] = [
     (
         fa.HopSkipJump(
-            steps=3, constraint="linf", gamma=1e3, initial_gradient_eval_steps=50
+            steps=3,
+            constraint="linf",
+            initial_gradient_eval_steps=100,
+            max_gradient_eval_steps=100,
         ),
         ep.inf,
     ),
     (
         fa.HopSkipJump(
-            steps=3, constraint="l2", initial_gradient_eval_steps=50, gamma=1e3
+            steps=3,
+            constraint="l2",
+            initial_gradient_eval_steps=100,
+            max_gradient_eval_steps=100,
         ),
         2,
     ),
@@ -29,8 +35,8 @@ attacks: List[Tuple[fa.Attack, Union[int, float]]] = [
         fa.HopSkipJump(
             steps=3,
             constraint="l2",
-            initial_gradient_eval_steps=50,
-            gamma=1e3,
+            initial_gradient_eval_steps=100,
+            max_gradient_eval_steps=100,
             stepsize_search="grid_search",
         ),
         2,

--- a/tests/test_hsj_attack.py
+++ b/tests/test_hsj_attack.py
@@ -15,7 +15,7 @@ def get_attack_id(x: Tuple[BrendelBethgeAttack, Union[int, float]]) -> str:
 attacks: List[Tuple[fa.Attack, Union[int, float]]] = [
     (
         fa.HopSkipJump(
-            steps=3,
+            steps=2,
             constraint="linf",
             initial_gradient_eval_steps=100,
             max_gradient_eval_steps=100,
@@ -24,7 +24,7 @@ attacks: List[Tuple[fa.Attack, Union[int, float]]] = [
     ),
     (
         fa.HopSkipJump(
-            steps=3,
+            steps=2,
             constraint="l2",
             initial_gradient_eval_steps=100,
             max_gradient_eval_steps=100,
@@ -33,11 +33,12 @@ attacks: List[Tuple[fa.Attack, Union[int, float]]] = [
     ),
     (
         fa.HopSkipJump(
-            steps=3,
+            steps=2,
             constraint="l2",
             initial_gradient_eval_steps=100,
             max_gradient_eval_steps=100,
             stepsize_search="grid_search",
+            gamma=1e5,
         ),
         2,
     ),


### PR DESCRIPTION
This PR implements the `HopSkipJump` attack as described in the [paper](https://arxiv.org/abs/1904.02144). The code is based on the reference [reference implementation](https://github.com/bethgelab/foolbox/blob/v2/foolbox/attacks/hop_skip_jump_attack.py).

There are still some test cases missing at the moment.