### PR TITLE
Made fb.plot.images more customizable.

### DIFF
--- a/foolbox/plot.py
+++ b/foolbox/plot.py
@@ -13,8 +13,10 @@ def images(
     nrows: Optional[int] = None,
     figsize: Optional[Tuple[float, float]] = None,
     scale: float = 1,
+    labels: Any = None,
+    return_fig: bool = False,
     **kwargs: Any,
-) -> None:
+) -> Optional[Tuple[Any, Any]]:
     import matplotlib.pyplot as plt
 
     x: ep.Tensor = ep.astensor(images)
@@ -57,7 +59,7 @@ def images(
         nrows=nrows,
         figsize=figsize,
         squeeze=False,
-        constrained_layout=True,
+        constrained_layout=False,
         **kwargs,
     )
 
@@ -68,5 +70,11 @@ def images(
             ax.set_yticks([])
             ax.axis("off")
             i = row * ncols + col
+            if labels is not None:
+                ax.set_title(labels[i])
             if i < len(x):
                 ax.imshow(x[i])
+
+    if return_fig:
+        return fig, axes
+    return None

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -13,6 +13,10 @@ def test_plot(dummy: ep.Tensor) -> None:
     fbn.plot.images(images, ncols=3)
     fbn.plot.images(images, nrows=2, ncols=6)
     fbn.plot.images(images, nrows=2, ncols=4)
+    fbn.plot.images(
+        images, nrows=2, ncols=4, labels=[str(i) for i in range(len(images))]
+    )
+    fbn.plot.images(images, nrows=2, ncols=4, return_fig=True)
     with pytest.raises(ValueError):
         images = ep.zeros(dummy, (10, 3, 3, 3))
         fbn.plot.images(images)


### PR DESCRIPTION
Example:
```py
distances = fb.distances.l2(images, advs)
dist_labels = [round(x,4) for x in distances.tolist()]
fb.plot.images(advs - images, labels=dist_labels, bounds=(-.1, .1))
```
Result:
![Capture](https://user-images.githubusercontent.com/1724399/107708927-501c7780-6c92-11eb-8e6c-b4cce69d2d3a.PNG)
