### PR TITLE
#619 fix wrong norm calculation

### DIFF
--- a/foolbox/attacks/saltandpepper.py
+++ b/foolbox/attacks/saltandpepper.py
@@ -89,7 +89,7 @@ class SaltAndPepperNoiseAttack(MinimizationAttack):
             x = ep.clip(x, min_, max_)
 
             # check if we found new best adversarials
-            norms = flatten(x).norms.l2(axis=-1)
+            norms = flatten(x - x0).norms.l2(axis=-1)
             closer = norms < best_advs_norms
             is_adv = is_adversarial(x)  # TODO: ignore those that are not closer anyway
             is_best_adv = ep.logical_and(is_adv, closer)


### PR DESCRIPTION
As pointed out by @maurapintor , the norm should be computed on the difference between `x` and `x0`, and not on `x` only.