### PR TITLE
Change default steps number to original implementation

### DIFF
--- a/foolbox/attacks/ddn.py
+++ b/foolbox/attacks/ddn.py
@@ -50,7 +50,7 @@ class DDNAttack(MinimizationAttack):
     distance = l2
 
     def __init__(
-        self, *, init_epsilon: float = 1.0, steps: int = 10, gamma: float = 0.05,
+        self, *, init_epsilon: float = 1.0, steps: int = 100, gamma: float = 0.05,
     ):
         self.init_epsilon = init_epsilon
         self.steps = steps


### PR DESCRIPTION
This attack was designed with a larger than ~100 number of steps in mind.
Having a default number of steps of 10 combined with gamma=0.05 leads to bad performance.