### PR TITLE
Fix single channel plotting

### DIFF
--- a/foolbox/plot.py
+++ b/foolbox/plot.py
@@ -69,4 +69,7 @@ def images(
             ax.axis("off")
             i = row * ncols + col
             if i < len(x):
-                ax.imshow(x[i])
+                if x.shape[-1] == 1:
+                    ax.imshow(x[i][:, :, 0])
+                else:
+                    ax.imshow(x[i])

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -13,6 +13,9 @@ def test_plot(dummy: ep.Tensor) -> None:
     fbn.plot.images(images, ncols=3)
     fbn.plot.images(images, nrows=2, ncols=6)
     fbn.plot.images(images, nrows=2, ncols=4)
+    # test for single channel images
+    images = ep.zeros(dummy, (10, 32, 32, 1))
+    fbn.plot.images(images)
     with pytest.raises(ValueError):
         images = ep.zeros(dummy, (10, 3, 3, 3))
         fbn.plot.images(images)


### PR DESCRIPTION
Fixed issue #630 (more information there).

A plot with one channel does look like this (fashion mnist):
![fmnist](https://user-images.githubusercontent.com/16451370/116602434-04da4280-a92c-11eb-9e31-36d4dbe8a52f.png)


Tests I did are in this notebook: https://gist.github.com/mastercaution/6f3bbb8fd82eafe569c76d177381c3a7