### PR TITLE
Bump up versions of test dependencies

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,8 +1,8 @@
-torch==1.4.0
-torchvision==0.5.0
-jaxlib==0.1.46
-jax==0.1.66
-tensorflow==2.5.0
+torch==1.10.0
+torchvision==0.11.3
+jaxlib==0.1.79
+jax==0.2.27
+tensorflow==2.7.0
 numba==0.50.1
 matplotlib==3.2.1
 pillow==8.1.1


### PR DESCRIPTION
This PR updates the version of the libraries we use for unit tests to the current versions of the frameworks we rely one, since the older one are either not available anymore or are practically less relevant than the latest versions.