### PR TITLE
Update HopSkipJump attack

### DIFF
--- a/docs/modules/attacks.rst
+++ b/docs/modules/attacks.rst
@@ -32,6 +32,8 @@
    BinarySearchContrastReductionAttack
    LinearSearchContrastReductionAttack
 
+   HopSkipJumpAttack
+
    L2CarliniWagnerAttack
    NewtonFoolAttack
    EADAttack

--- a/foolbox/attacks/__init__.py
+++ b/foolbox/attacks/__init__.py
@@ -56,7 +56,7 @@ from .blended_noise import LinearSearchBlendedUniformNoiseAttack  # noqa: F401
 from .binarization import BinarizationRefinementAttack  # noqa: F401
 from .dataset_attack import DatasetAttack  # noqa: F401
 from .boundary_attack import BoundaryAttack  # noqa: F401
-from .hop_skip_jump import HopSkipJump  # noqa: F401
+from .hop_skip_jump import HopSkipJumpAttack  # noqa: F401
 from .brendel_bethge import (  # noqa: F401
     L0BrendelBethgeAttack,
     L1BrendelBethgeAttack,

--- a/foolbox/attacks/hop_skip_jump.py
+++ b/foolbox/attacks/hop_skip_jump.py
@@ -24,7 +24,7 @@ from .base import raise_if_kwargs
 from ..distances import l2, linf
 
 
-class HopSkipJump(MinimizationAttack):
+class HopSkipJumpAttack(MinimizationAttack):
     """A powerful adversarial attack that requires neither gradients
     nor probabilities [#Chen19].
 
@@ -251,7 +251,7 @@ class HopSkipJump(MinimizationAttack):
         perturbed = ep.expand_dims(x_advs, 0) + scaled_rv
         perturbed = ep.clip(perturbed, 0, 1)
 
-        rv = (perturbed - x_advs) / atleast_kd(ep.expand_dims(delta, 0), rv.ndim)
+        rv = (perturbed - x_advs) / atleast_kd(ep.expand_dims(delta + 1e-8, 0), rv.ndim)
 
         multipliers_list: List[ep.Tensor] = []
         for step in range(steps):

--- a/tests/test_hsj_attack.py
+++ b/tests/test_hsj_attack.py
@@ -16,7 +16,7 @@ def get_attack_id(x: Tuple[BrendelBethgeAttack, Union[int, float]]) -> str:
 
 attacks: List[Tuple[fa.Attack, Union[int, float]]] = [
     (
-        fa.HopSkipJump(
+        fa.HopSkipJumpAttack(
             steps=1,
             constraint="linf",
             initial_gradient_eval_steps=100,
@@ -25,7 +25,7 @@ attacks: List[Tuple[fa.Attack, Union[int, float]]] = [
         ep.inf,
     ),
     (
-        fa.HopSkipJump(
+        fa.HopSkipJumpAttack(
             steps=1,
             constraint="l2",
             initial_gradient_eval_steps=100,
@@ -34,7 +34,7 @@ attacks: List[Tuple[fa.Attack, Union[int, float]]] = [
         2,
     ),
     (
-        fa.HopSkipJump(
+        fa.HopSkipJumpAttack(
             steps=1,
             constraint="l2",
             initial_gradient_eval_steps=100,
@@ -51,7 +51,7 @@ attacks: List[Tuple[fa.Attack, Union[int, float]]] = [
 def test_hsj_untargeted_attack(
     request: Any,
     fmodel_and_data_ext_for_attacks: ModeAndDataAndDescription,
-    attack_and_p: Tuple[fa.HopSkipJump, Union[int, float]],
+    attack_and_p: Tuple[fa.HopSkipJumpAttack, Union[int, float]],
 ) -> None:
     if request.config.option.skipslow:
         pytest.skip()
@@ -87,7 +87,7 @@ def test_hsj_untargeted_attack(
 def test_hsj_targeted_attack(
     request: Any,
     fmodel_and_data_ext_for_attacks: ModeAndDataAndDescription,
-    attack_and_p: Tuple[fa.HopSkipJump, Union[int, float]],
+    attack_and_p: Tuple[fa.HopSkipJumpAttack, Union[int, float]],
 ) -> None:
     if request.config.option.skipslow:
         pytest.skip()


### PR DESCRIPTION
This closes #670.

- Renames attack class to `HopSkipJumpAttack`
- Add this attack to the attack overview on the documentation