### PR TITLE
Add MIFGSM Attack

### DIFF
--- a/foolbox/attacks/__init__.py
+++ b/foolbox/attacks/__init__.py
@@ -20,6 +20,11 @@ from .basic_iterative_method import (  # noqa: F401
     L2AdamBasicIterativeAttack,
     LinfAdamBasicIterativeAttack,
 )
+from .mi_fgsm import (  # noqa: F401
+    L1MomentumIterativeFastGradientMethod,
+    L2MomentumIterativeFastGradientMethod,
+    LinfMomentumIterativeFastGradientMethod,
+)
 from .fast_gradient_method import (  # noqa: F401
     L1FastGradientAttack,
     L2FastGradientAttack,
@@ -93,6 +98,7 @@ L1PGD = L1ProjectedGradientDescentAttack
 L2PGD = L2ProjectedGradientDescentAttack
 LinfPGD = LinfProjectedGradientDescentAttack
 PGD = LinfPGD
+MIFGSM = LinfMomentumIterativeFastGradientMethod
 
 L1AdamPGD = L1AdamProjectedGradientDescentAttack
 L2AdamPGD = L2AdamProjectedGradientDescentAttack

--- a/foolbox/attacks/mi_fgsm.py
+++ b/foolbox/attacks/mi_fgsm.py
@@ -80,11 +80,11 @@ class L2MomentumIterativeFastGradientMethod(L2BasicIterativeAttack):
 
 
 class LinfMomentumIterativeFastGradientMethod(LinfBasicIterativeAttack):
-    """create I-FGSM with Momentum [#Dong18]
+    """Momentum Iterative Fast Gradient Sign Method (MI-FGSM) [#Dong18]
 
     References: .. [#Dong18] Dong Y, Liao F, Pang T, et al. Boosting adversarial attacks with momentum[
     C]//Proceedings of the IEEE conference on computer vision and pattern recognition. 2018: 9185-9193.
-    https://arxiv.org/abs/1607.02533
+    https://arxiv.org/abs/1710.06081
     """
 
     def __init__(

--- a/foolbox/attacks/mi_fgsm.py
+++ b/foolbox/attacks/mi_fgsm.py
@@ -1,5 +1,5 @@
 from functools import partial
-from typing import Callable, Union, Optional
+from typing import Callable, Optional
 
 from foolbox.attacks.gradient_descent_base import normalize_lp_norms
 

--- a/foolbox/attacks/mi_fgsm.py
+++ b/foolbox/attacks/mi_fgsm.py
@@ -1,0 +1,75 @@
+from functools import partial
+from typing import Callable
+
+from foolbox.attacks.gradient_descent_base import normalize_lp_norms
+
+from .basic_iterative_method import Optimizer, L1BasicIterativeAttack, L2BasicIterativeAttack, LinfBasicIterativeAttack
+import eagerpy as ep
+
+
+class GDMOptimizer(Optimizer):
+    # create GD optimizer with momentum
+    def __init__(
+            self,
+            x: ep.Tensor,
+            stepsize: float,
+            momentum: float = 1.,
+            normalize_fn: Callable[[ep.Tensor], ep.Tensor] = lambda x: x.sign(),
+    ):
+        self.stepsize = stepsize
+        self.momentum = momentum
+        self.normalize = normalize_fn
+        self.accumulation_grad = ep.zeros_like(x)
+
+    def __call__(self, gradient: ep.Tensor) -> ep.Tensor:
+        self.accumulation_grad = self.momentum * self.accumulation_grad + gradient
+        return self.stepsize * self.normalize(self.accumulation_grad)
+
+
+class L1MomentumIterativeFastGradientMethod(L1BasicIterativeAttack):
+    def __init__(
+            self,
+            *,
+            momentum: float = 1.,
+            **kwargs,
+    ):
+        self.momentum = momentum
+        super().__init__(**kwargs)
+
+    def get_optimizer(self, x: ep.Tensor, stepsize: float) -> Optimizer:
+        return GDMOptimizer(x, stepsize, self.momentum, partial(normalize_lp_norms, p=1))
+
+
+class L2MomentumIterativeFastGradientMethod(L2BasicIterativeAttack):
+    def __init__(
+            self,
+            *,
+            momentum: float = 1.,
+            **kwargs,
+    ):
+        self.momentum = momentum
+        super().__init__(**kwargs)
+
+    def get_optimizer(self, x: ep.Tensor, stepsize: float) -> Optimizer:
+        return GDMOptimizer(x, stepsize, self.momentum, partial(normalize_lp_norms, p=2))
+
+
+class LinfMomentumIterativeFastGradientMethod(LinfBasicIterativeAttack):
+    """create I-FGSM with Momentum [#Dong18]
+
+    References: .. [#Dong18] Dong Y, Liao F, Pang T, et al. Boosting adversarial attacks with momentum[
+    C]//Proceedings of the IEEE conference on computer vision and pattern recognition. 2018: 9185-9193.
+    https://arxiv.org/abs/1607.02533
+    """
+
+    def __init__(
+            self,
+            *,
+            momentum: float = 1.,
+            **kwargs,
+    ):
+        self.momentum = momentum
+        super().__init__(**kwargs)
+
+    def get_optimizer(self, x: ep.Tensor, stepsize: float) -> Optimizer:
+        return GDMOptimizer(x, stepsize, self.momentum)

--- a/foolbox/attacks/mi_fgsm.py
+++ b/foolbox/attacks/mi_fgsm.py
@@ -1,5 +1,5 @@
 from functools import partial
-from typing import Callable
+from typing import Callable, Union, Optional
 
 from foolbox.attacks.gradient_descent_base import normalize_lp_norms
 
@@ -36,10 +36,18 @@ class L1MomentumIterativeFastGradientMethod(L1BasicIterativeAttack):
         self,
         *,
         momentum: float = 1.0,
-        **kwargs,
+        rel_stepsize: float = 0.2,
+        abs_stepsize: Optional[float] = None,
+        steps: int = 10,
+        random_start: bool = False,
     ):
         self.momentum = momentum
-        super().__init__(**kwargs)
+        super().__init__(
+            rel_stepsize=rel_stepsize,
+            abs_stepsize=abs_stepsize,
+            steps=steps,
+            random_start=random_start,
+        )
 
     def get_optimizer(self, x: ep.Tensor, stepsize: float) -> Optimizer:
         return GDMOptimizer(
@@ -52,10 +60,18 @@ class L2MomentumIterativeFastGradientMethod(L2BasicIterativeAttack):
         self,
         *,
         momentum: float = 1.0,
-        **kwargs,
+        rel_stepsize: float = 0.2,
+        abs_stepsize: Optional[float] = None,
+        steps: int = 10,
+        random_start: bool = False,
     ):
         self.momentum = momentum
-        super().__init__(**kwargs)
+        super().__init__(
+            rel_stepsize=rel_stepsize,
+            abs_stepsize=abs_stepsize,
+            steps=steps,
+            random_start=random_start,
+        )
 
     def get_optimizer(self, x: ep.Tensor, stepsize: float) -> Optimizer:
         return GDMOptimizer(
@@ -75,10 +91,18 @@ class LinfMomentumIterativeFastGradientMethod(LinfBasicIterativeAttack):
         self,
         *,
         momentum: float = 1.0,
-        **kwargs,
+        rel_stepsize: float = 0.2,
+        abs_stepsize: Optional[float] = None,
+        steps: int = 10,
+        random_start: bool = False,
     ):
         self.momentum = momentum
-        super().__init__(**kwargs)
+        super().__init__(
+            rel_stepsize=rel_stepsize,
+            abs_stepsize=abs_stepsize,
+            steps=steps,
+            random_start=random_start,
+        )
 
     def get_optimizer(self, x: ep.Tensor, stepsize: float) -> Optimizer:
         return GDMOptimizer(x, stepsize, self.momentum)

--- a/foolbox/attacks/mi_fgsm.py
+++ b/foolbox/attacks/mi_fgsm.py
@@ -3,18 +3,23 @@ from typing import Callable
 
 from foolbox.attacks.gradient_descent_base import normalize_lp_norms
 
-from .basic_iterative_method import Optimizer, L1BasicIterativeAttack, L2BasicIterativeAttack, LinfBasicIterativeAttack
+from .basic_iterative_method import (
+    Optimizer,
+    L1BasicIterativeAttack,
+    L2BasicIterativeAttack,
+    LinfBasicIterativeAttack,
+)
 import eagerpy as ep
 
 
 class GDMOptimizer(Optimizer):
     # create GD optimizer with momentum
     def __init__(
-            self,
-            x: ep.Tensor,
-            stepsize: float,
-            momentum: float = 1.,
-            normalize_fn: Callable[[ep.Tensor], ep.Tensor] = lambda x: x.sign(),
+        self,
+        x: ep.Tensor,
+        stepsize: float,
+        momentum: float = 1.0,
+        normalize_fn: Callable[[ep.Tensor], ep.Tensor] = lambda x: x.sign(),
     ):
         self.stepsize = stepsize
         self.momentum = momentum
@@ -28,30 +33,34 @@ class GDMOptimizer(Optimizer):
 
 class L1MomentumIterativeFastGradientMethod(L1BasicIterativeAttack):
     def __init__(
-            self,
-            *,
-            momentum: float = 1.,
-            **kwargs,
+        self,
+        *,
+        momentum: float = 1.0,
+        **kwargs,
     ):
         self.momentum = momentum
         super().__init__(**kwargs)
 
     def get_optimizer(self, x: ep.Tensor, stepsize: float) -> Optimizer:
-        return GDMOptimizer(x, stepsize, self.momentum, partial(normalize_lp_norms, p=1))
+        return GDMOptimizer(
+            x, stepsize, self.momentum, partial(normalize_lp_norms, p=1)
+        )
 
 
 class L2MomentumIterativeFastGradientMethod(L2BasicIterativeAttack):
     def __init__(
-            self,
-            *,
-            momentum: float = 1.,
-            **kwargs,
+        self,
+        *,
+        momentum: float = 1.0,
+        **kwargs,
     ):
         self.momentum = momentum
         super().__init__(**kwargs)
 
     def get_optimizer(self, x: ep.Tensor, stepsize: float) -> Optimizer:
-        return GDMOptimizer(x, stepsize, self.momentum, partial(normalize_lp_norms, p=2))
+        return GDMOptimizer(
+            x, stepsize, self.momentum, partial(normalize_lp_norms, p=2)
+        )
 
 
 class LinfMomentumIterativeFastGradientMethod(LinfBasicIterativeAttack):
@@ -63,10 +72,10 @@ class LinfMomentumIterativeFastGradientMethod(LinfBasicIterativeAttack):
     """
 
     def __init__(
-            self,
-            *,
-            momentum: float = 1.,
-            **kwargs,
+        self,
+        *,
+        momentum: float = 1.0,
+        **kwargs,
     ):
         self.momentum = momentum
         super().__init__(**kwargs)

--- a/foolbox/attacks/mi_fgsm.py
+++ b/foolbox/attacks/mi_fgsm.py
@@ -13,7 +13,15 @@ import eagerpy as ep
 
 
 class GDMOptimizer(Optimizer):
-    # create GD optimizer with momentum
+    """Momentum-based Gradient Descent Optimizer
+
+    Args:
+        x : Optimization variable for initialization of accumulation grad
+        stepsize : Stepsize for gradient descent
+        momentum : Momentum factor for accumulation grad
+        normalize_fn : Function to normalize the gradient
+    """
+
     def __init__(
         self,
         x: ep.Tensor,
@@ -32,6 +40,16 @@ class GDMOptimizer(Optimizer):
 
 
 class L1MomentumIterativeFastGradientMethod(L1BasicIterativeAttack):
+    """L1 Momentum Iterative Fast Gradient Sign Method (MI-FGSM) [#Dong18]
+
+    Args:
+        momentum : Momentum factor for accumulation grad
+        rel_stepsize : Stepsize relative to epsilon
+        abs_stepsize : If given, it takes precedence over rel_stepsize.
+        steps : Number of update steps to perform.
+        random_start : Whether the perturbation is initialized randomly or starts at zero.
+    """
+
     def __init__(
         self,
         *,
@@ -56,6 +74,16 @@ class L1MomentumIterativeFastGradientMethod(L1BasicIterativeAttack):
 
 
 class L2MomentumIterativeFastGradientMethod(L2BasicIterativeAttack):
+    """L2 Momentum Iterative Fast Gradient Sign Method (MI-FGSM) [#Dong18]
+
+    Args:
+        momentum : Momentum factor for accumulation grad
+        rel_stepsize : Stepsize relative to epsilon
+        abs_stepsize : If given, it takes precedence over rel_stepsize.
+        steps : Number of update steps to perform.
+        random_start : Whether the perturbation is initialized randomly or starts at zero.
+    """
+
     def __init__(
         self,
         *,
@@ -80,7 +108,14 @@ class L2MomentumIterativeFastGradientMethod(L2BasicIterativeAttack):
 
 
 class LinfMomentumIterativeFastGradientMethod(LinfBasicIterativeAttack):
-    """Momentum Iterative Fast Gradient Sign Method (MI-FGSM) [#Dong18]
+    """Linf Momentum Iterative Fast Gradient Sign Method (MI-FGSM) [#Dong18]
+
+    Args:
+        momentum : Momentum factor for accumulation grad
+        rel_stepsize : Stepsize relative to epsilon
+        abs_stepsize : If given, it takes precedence over rel_stepsize.
+        steps : Number of update steps to perform.
+        random_start : Whether the perturbation is initialized randomly or starts at zero.
 
     References: .. [#Dong18] Dong Y, Liao F, Pang T, et al. Boosting adversarial attacks with momentum[
     C]//Proceedings of the IEEE conference on computer vision and pattern recognition. 2018: 9185-9193.

--- a/tests/test_attacks.py
+++ b/tests/test_attacks.py
@@ -94,6 +94,15 @@ attacks: List[AttackTestTarget] = [
     AttackTestTarget(fa.FGSM(), Linf(100.0), uses_grad=True),
     AttackTestTarget(FGSM_GE(), Linf(100.0)),
     AttackTestTarget(fa.FGM(), L2(100.0), uses_grad=True),
+    AttackTestTarget(
+        fa.LinfMomentumIterativeFastGradientMethod(), Linf(1.0), uses_grad=True
+    ),
+    AttackTestTarget(
+        fa.L2MomentumIterativeFastGradientMethod(), L2(50.0), uses_grad=True
+    ),
+    AttackTestTarget(
+        fa.L1MomentumIterativeFastGradientMethod(), 5000.0, uses_grad=True
+    ),
     AttackTestTarget(fa.L1FastGradientAttack(), 5000.0, uses_grad=True),
     AttackTestTarget(
         fa.GaussianBlurAttack(steps=10), uses_grad=True, requires_real_model=True
@@ -243,6 +252,15 @@ targeted_attacks: List[AttackTestTarget] = [
     ),
     AttackTestTarget(fa.L2AdamBasicIterativeAttack(), L2(50.0), uses_grad=True),
     AttackTestTarget(fa.L1AdamBasicIterativeAttack(), 5000.0, uses_grad=True),
+    AttackTestTarget(
+        fa.LinfMomentumIterativeFastGradientMethod(), Linf(1.0), uses_grad=True
+    ),
+    AttackTestTarget(
+        fa.L2MomentumIterativeFastGradientMethod(), L2(50.0), uses_grad=True
+    ),
+    AttackTestTarget(
+        fa.L1MomentumIterativeFastGradientMethod(), 5000.0, uses_grad=True
+    ),
     AttackTestTarget(fa.SparseL1DescentAttack(), 5000.0, uses_grad=True),
 ]
 


### PR DESCRIPTION
This code implements the fixed epsilon attack, MI-FGSM (https://openaccess.thecvf.com/content_cvpr_2018/html/Dong_Boosting_Adversarial_Attacks_CVPR_2018_paper.html).
MI-FGSM is a classic method that demonstrates superior and robust performance compared to PGD. It's worth noting that MI-FGSM serves as a baseline for many SOTA research papers. Therefore, implementing MI-FGSM proves to be a convenient choice for researchers. Please feel free to share any suggestions for further improvements to the code.

(I close the last request, because I rebase the code by mistakes.)