### PR TITLE
Replace deprecated `is_gpu_available()` calls

### DIFF
--- a/foolbox/models/tensorflow.py
+++ b/foolbox/models/tensorflow.py
@@ -10,7 +10,7 @@ def get_device(device: Any) -> Any:
     import tensorflow as tf
 
     if device is None:
-        device = tf.device("/GPU:0" if tf.test.is_gpu_available() else "/CPU:0")
+        device = tf.device("/GPU:0" if tf.config.list_physical_devices("GPU") else "/CPU:0")
     if isinstance(device, str):
         device = tf.device(device)
     return device

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -266,7 +266,7 @@ def tensorflow_resnet50(request: Any) -> ModelAndData:
 
     import tensorflow as tf
 
-    if not tf.test.is_gpu_available():
+    if not list_physical_devices("GPU"):
         pytest.skip("ResNet50 test too slow without GPU")
 
     model = tf.keras.applications.ResNet50(weights="imagenet")


### PR DESCRIPTION
When running foolbox using a tensorflow-based model you get the following error:

```
WARNING:tensorflow:From .../foolbox/models/tensorflow.py:13: is_gpu_available (from tensorflow.python.framework.test_util) is deprecated and will be removed in a future version.
Instructions for updating:
Use `tf.config.list_physical_devices('GPU')` instead.
```

this pr implements such suggestion